### PR TITLE
Fix default mode in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ $ stackprof tmp/stackprof-cpu-*.dump --method 'Object#present?'
 
 four sampling modes are supported:
 
-  - :wall (using `ITIMER_REAL` and `SIGALRM`) [default mode]
-  - :cpu (using `ITIMER_PROF` and `SIGPROF`)
+  - :wall (using `ITIMER_REAL` and `SIGALRM`)
+  - :cpu (using `ITIMER_PROF` and `SIGPROF`) [default mode]
   - :object (using `RUBY_INTERNAL_EVENT_NEWOBJ`)
   - :custom (user-defined via `StackProf.sample`)
 


### PR DESCRIPTION
Here's the actual default mode: https://github.com/tmm1/stackprof/blob/master/lib/stackprof/middleware.rb#L10
