### PR TITLE
Fix #11

### DIFF
--- a/bin/stackprof
+++ b/bin/stackprof
@@ -13,10 +13,10 @@ parser = OptionParser.new(ARGV) do |o|
 
   o.on('--text', 'Text summary per method (default)'){ options[:format] = :text }
   o.on('--files', 'List of files'){ |f| options[:format] = :files }
-  o.on('--limit=[num]', Integer, 'Limit --text or --files output to N lines'){ |n| options[:limit] = n }
+  o.on('--limit [num]', Integer, 'Limit --text or --files output to N lines'){ |n| options[:limit] = n }
   o.on('--sort-total', "Sort --text or --files output on total samples\n\n"){ options[:sort] = true }
-  o.on('--method=[grep]', 'Zoom into specified method'){ |f| options[:format] = :method; options[:filter] = f }
-  o.on('--file=[grep]', 'Show annotated code for specified file'){ |f| options[:format] = :file; options[:filter] = f }
+  o.on('--method [grep]', 'Zoom into specified method'){ |f| options[:format] = :method; options[:filter] = f }
+  o.on('--file [grep]', 'Show annotated code for specified file'){ |f| options[:format] = :file; options[:filter] = f }
   o.on('--callgrind', 'Callgrind output (use with kcachegrind, gprof2dot)'){ options[:format] = :callgrind }
   o.on('--graphviz', "Graphviz output (use with dot)\n\n"){ options[:format] = :graphviz }
   o.on('--debug', 'Pretty print raw profile data'){ options[:format] = :debug }


### PR DESCRIPTION
The `=` sign is required because it's not inside the square brackets:

[bin/stackprof#L16](https://github.com/tmm1/stackprof/blob/master/bin/stackprof#L16)

``` ruby
o.on('--limit=[num]', ... )
```

[bin/stackprof#L18](https://github.com/tmm1/stackprof/blob/master/bin/stackprof#L18)

``` ruby
o.on('--method=[grep]', ... )
```

[bin/stackprof#L19](https://github.com/tmm1/stackprof/blob/master/bin/stackprof#L19)

``` ruby
o.on('--file=[grep]', ... )
```

This fixes the bug.
