### PR TITLE
Allow for passing a specific filename to Middleware.save

### DIFF
--- a/lib/stackprof/middleware.rb
+++ b/lib/stackprof/middleware.rb
@@ -31,13 +31,14 @@ module StackProf
       attr_accessor :enabled, :mode, :interval, :path
       alias enabled? enabled
 
-      def save
+      def save(filename = nil)
         if results = StackProf.results
           FileUtils.mkdir_p(Middleware.path)
-          filename = "stackprof-#{results[:mode]}-#{Process.pid}-#{Time.now.to_i}.dump"
-          File.open(File.join(Middleware.path, filename), 'wb') do |f| 
+          filename ||= "stackprof-#{results[:mode]}-#{Process.pid}-#{Time.now.to_i}.dump"
+          File.open(File.join(Middleware.path, filename), 'wb') do |f|
             f.write Marshal.dump(results)
           end
+          filename
         end
       end
 


### PR DESCRIPTION
Also return the filename instead of the return value of .open()
This allows for overwritting the same file when calling .save
manually as well as keeping track of the exact file written (using
the return value)
