### PR TITLE
Add link to stackprof-webnav

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ $ stackprof tmp/stackprof-cpu-*.dump --method 'Object#present?'
                                     |    22  |   end
 ```
 
+For an experimental version of WebUI reporting of stackprof, see [stackprof-webnav](https://github.com/alisnic/stackprof-webnav)
+
 ### sampling
 
 four sampling modes are supported:


### PR DESCRIPTION
I made a small gem to navigate stackprof dumps in a web ui. It made analyzing the dumps a lot of fun, I think some people may find it useful.
