### PR TITLE
Don't escape method filter regexp

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -234,7 +234,7 @@ module StackProf
     end
 
     def print_method(name, f = STDOUT)
-      name = /#{Regexp.escape name}/ unless Regexp === name
+      name = /#{name}/ unless Regexp === name
       frames.each do |frame, info|
         next unless info[:name] =~ name
         file, line = info.values_at(:file, :line)


### PR DESCRIPTION
The regular expression value passed to `--method` is being incorrectly escaped. This leads to the inability to perform searches for things like `foo.*bar`, because the dot character is escaped and the resulting regexp becomes `foo\.*bar`.