### PR TITLE
Fix buffer overflow in stackprof_record_sample()

### DIFF
--- a/ext/stackprof.c
+++ b/ext/stackprof.c
@@ -346,7 +346,7 @@ stackprof_record_sample()
     VALUE prev_frame = Qnil;
 
     _stackprof.overall_samples++;
-    num = rb_profile_frames(0, sizeof(_stackprof.frames_buffer), _stackprof.frames_buffer, _stackprof.lines_buffer);
+    num = rb_profile_frames(0, sizeof(_stackprof.frames_buffer) / sizeof(VALUE), _stackprof.frames_buffer, _stackprof.lines_buffer);
 
     if (_stackprof.raw) {
 	int found = 0;


### PR DESCRIPTION
Fixes an overflow where `rb_profile_frames` was being passed an incorrect value for the `limit` parameter.
