### PR TITLE
Allow for mode to be set via a proc too

### DIFF
--- a/test/test_middleware.rb
+++ b/test/test_middleware.rb
@@ -60,4 +60,38 @@ class StackProf::MiddlewareTest < Test::Unit::TestCase
     assert StackProf::Middleware.enabled?(env)
   end
 
+  def test_mode_should_the_same_value_passed_when_no_proc
+    env = {}
+    expected_mode = :wall
+    StackProf::Middleware.new(Object.new, mode: expected_mode)
+    assert_equal expected_mode, StackProf::Middleware.mode(env)
+  end
+
+  def test_mode_should_be_the_return_value_of_the_proc_when_passed
+    proc_called = false
+    expected_mode = :foo
+    env = Hash.new { expected_mode }
+
+    mode_proc = Proc.new do |env|
+      proc_called = true
+      env['MODE']
+    end
+
+    StackProf::Middleware.new(Object.new, mode: mode_proc)
+    assert_equal expected_mode, StackProf::Middleware.mode(env)
+    assert proc_called
+  end
+
+  def test_mode_will_not_change_in_within_the_same_profile_capture
+    app = Proc.new{ ['200', {'Content-Type' => 'omg/ponies'}, ['-']] }
+    modes = [:wall, :cpu]
+    mode_proc = Proc.new { modes.shift }
+    middleware = StackProf::Middleware.new(app, enabled: true, mode: mode_proc, save_every: 3)
+
+    StackProf.expects(:start).with(mode: :wall, interval: StackProf::Middleware.interval).times(3)
+    3.times{ middleware.call({}) }
+    StackProf.expects(:start).with(mode: :cpu, interval: StackProf::Middleware.interval).times(3)
+    3.times{ middleware.call({}) }
+  end
+
 end


### PR DESCRIPTION
## Problem

When profiling a live app, it is very convenient to not only turn the profiler on and off but to be able to change the profiling mode according to some environment configuration.
## Solution

Allow for a proc to return the mode value, being careful to not change the mode until a call to save has been made.
