### PR TITLE
Fix a typo in middleware.rb

### DIFF
--- a/lib/stackprof/middleware.rb
+++ b/lib/stackprof/middleware.rb
@@ -11,7 +11,7 @@ module StackProf
       Middleware.interval = options[:interval] || 1000
       Middleware.enabled  = options[:enabled]
       Middleware.path     = options[:path] || 'tmp'
-      at_exit{ Middleware.save? } if options[:save_at_exit]
+      at_exit{ Middleware.save } if options[:save_at_exit]
     end
 
     def call(env)


### PR DESCRIPTION
I got this error before my commit:

```
/home/nono/.gem/ruby/2.1.1/gems/stackprof-0.2.6/lib/stackprof/middleware.rb:14:in `block in initialize': undefined method `save?' for StackProf::Middleware:Class (NoMethodError)
```
