### PR TITLE
Add raw option for StackProf::Middleware

### DIFF
--- a/lib/stackprof/middleware.rb
+++ b/lib/stackprof/middleware.rb
@@ -9,6 +9,7 @@ module StackProf
 
       Middleware.mode     = options[:mode] || :cpu
       Middleware.interval = options[:interval] || 1000
+      Middleware.raw      = options[:raw] || false
       Middleware.enabled  = options[:enabled]
       Middleware.path     = options[:path] || 'tmp'
       at_exit{ Middleware.save } if options[:save_at_exit]
@@ -29,7 +30,7 @@ module StackProf
     end
 
     class << self
-      attr_accessor :enabled, :mode, :interval, :path
+      attr_accessor :enabled, :mode, :interval, :raw, :path
 
       def enabled?(env)
         if enabled.respond_to?(:call)

--- a/test/test_middleware.rb
+++ b/test/test_middleware.rb
@@ -55,9 +55,13 @@ class StackProf::MiddlewareTest < MiniTest::Test
     StackProf::Middleware.new(Object.new, enabled: enable_proc)
     refute StackProf::Middleware.enabled?(env)
 
-    env = Hash.new { true}
+    env = Hash.new { true }
     StackProf::Middleware.new(Object.new, enabled: enable_proc)
     assert StackProf::Middleware.enabled?(env)
   end
 
+  def test_raw
+    StackProf::Middleware.new(Object.new, raw: true)
+    assert StackProf::Middleware.raw
+  end
 end


### PR DESCRIPTION
Add raw option for StackProf::Middleware.

When this option is enabled, the report can convert flamegraph and so on.

Usage is below.

```
use StackProf::Middleware, enabled: true,
                           mode: :cpu,
                           interval: 1000,
                           save_every: 5,
                           raw: true
```