### PR TITLE
Pass optional io to Report#print_dump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stackprof (0.2.6)
+    stackprof (0.2.7)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -63,8 +63,8 @@ module StackProf
       pp @data
     end
 
-    def print_dump
-      puts Marshal.dump(@data.reject{|k,v| k == :files })
+    def print_dump(f=STDOUT)
+      f.puts Marshal.dump(@data.reject{|k,v| k == :files })
     end
 
     def print_stackcollapse

--- a/test/test_report.rb
+++ b/test/test_report.rb
@@ -1,0 +1,22 @@
+$:.unshift File.expand_path('../../lib', __FILE__)
+require 'stackprof'
+require 'minitest/autorun'
+
+class ReportDumpTest < MiniTest::Test
+  def test_dump_to_stdout
+    data = {}
+    report = StackProf::Report.new(data)
+
+    out, _err = capture_subprocess_io do
+      report.print_dump
+    end
+
+    assert_dump data, out
+  end
+
+  private
+
+  def assert_dump(expected, marshal_data)
+    assert_equal expected, Marshal.load(marshal_data)
+  end
+end

--- a/test/test_report.rb
+++ b/test/test_report.rb
@@ -3,6 +3,8 @@ require 'stackprof'
 require 'minitest/autorun'
 
 class ReportDumpTest < MiniTest::Test
+  require 'stringio'
+
   def test_dump_to_stdout
     data = {}
     report = StackProf::Report.new(data)
@@ -12,6 +14,16 @@ class ReportDumpTest < MiniTest::Test
     end
 
     assert_dump data, out
+  end
+
+  def test_dump_to_file
+    data = {}
+    f = StringIO.new
+    report = StackProf::Report.new(data)
+
+    report.print_dump(f)
+
+    assert_dump data, f.string
   end
 
   private


### PR DESCRIPTION
After this change you can dump your profile results to any IO via:

```ruby
report = StackProf::Report.new(StackProf.results)
File.open("profile.dump", "wb") do |io|
  report.print_dump(io)
end
```
