### PR TITLE
Fix modeline

### DIFF
--- a/ext/stackprof.c
+++ b/ext/stackprof.c
@@ -2,7 +2,7 @@
 
   stackprof.c - Sampling call-stack frame profiler for MRI.
 
-  vim: setl noexpandtab shiftwidth=4 tabstop=8 softtabstop=4
+  vim: noexpandtab shiftwidth=4 tabstop=8 softtabstop=4
 
 **********************************************************************/
 


### PR DESCRIPTION
When opens `stackprof.c` by Vim, an error is raised as follows.

```sh
$ vim ext/stackprof.c
"ext/stackprof.c" 547L, 14784C
Error detected while processing modelines:
line    5:
E518: Unknown option: setl 
E518: Unknown option: setl 
```

According to Vim help, `setl` is not necessary.

https://github.com/vim/vim/blob/master/runtime/doc/options.txt#L479-L512
