### PR TITLE
Better method examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,9 @@ multiple start/stop invocations.
 
 ``` ruby
 StackProf.running?
-StackProf.start
+StackProf.start(mode: :cpu)
 StackProf.stop
-StackProf.results
+StackProf.results('/tmp/some.file')
 ```
 
 ### all options


### PR DESCRIPTION
I had to dive into the C source to figure out how to call StackProf without a block because the methods listed in the README don't show their arguments.