### PR TITLE
Avoid "stack level too deep" error

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -9,7 +9,7 @@ module StackProf
     attr_reader :data
 
     def frames(sort_by_total=false)
-      Hash[ *@data[:frames].sort_by{ |iseq, stats| -stats[sort_by_total ? :total_samples : :samples] }.flatten(1) ]
+      *@data[:frames].sort_by{ |iseq, stats| -stats[sort_by_total ? :total_samples : :samples] }.inject({}){|h, (k, v)| h[k] = v; h}
     end
 
     def normalized_frames


### PR DESCRIPTION
When too many frames are included in the data,  Stackprof raises `SystemStackError(stack level too deep)` at constructing the Hash object from `@data[:frames]`.

```
/home/ozaki/dev/asp_weborder/vendor/bundle/ruby/2.2.0/gems/stackprof-0.2.7/lib/stackprof/report.rb:12:in `frames': stack level too deep (SystemStackError)
        from /home/ozaki/dev/asp_weborder/vendor/bundle/ruby/2.2.0/gems/stackprof-0.2.7/lib/stackprof/report.rb:199:in `print_text'
        from /home/ozaki/dev/asp_weborder/vendor/bundle/ruby/2.2.0/gems/stackprof-0.2.7/bin/stackprof:48:in `<top (required)>'
        from /home/ozaki/dev/asp_weborder/vendor/bundle/ruby/2.2.0/bin/stackprof:23:in `load'
        from /home/ozaki/dev/asp_weborder/vendor/bundle/ruby/2.2.0/bin/stackprof:23:in `<main>'
```

For avoiding this error, I rewrote `frames` method by `Hash#inject` instead of using `Hash[ *@data[:frames] ...]`  

F.Y.I 
https://bugs.ruby-lang.org/issues/5719