### PR TITLE
prevent frames from being GC'd

### DIFF
--- a/ext/stackprof.c
+++ b/ext/stackprof.c
@@ -529,7 +529,7 @@ Init_stackprof(void)
     S(aggregate);
 #undef S
 
-    gc_hook = Data_Wrap_Struct(rb_cObject, stackprof_gc_mark, NULL, NULL);
+    gc_hook = Data_Wrap_Struct(rb_cObject, stackprof_gc_mark, NULL, &_stackprof);
     rb_global_variable(&gc_hook);
 
     rb_mStackProf = rb_define_module("StackProf");


### PR DESCRIPTION
I'm not sure what commit changed this, but if we don't provide a value
for `Data_Wrap_Struct`, the object won't get marked.  Since the object
doesn't get marked, frames we've collected won't get marked and we'll
get a segv at report time.

Fixes #58 

I should mention this started between Ruby 2.2 and 2.3.  I haven't tracked down the commit that changed it, but I'm not sure I care that much. :-/