### PR TITLE
Delete `rb_autoload` from C source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /tmp
-/lib/stackprof.bundle
-/lib/stackprof.so
+/lib/stackprof/stackprof.bundle
+/lib/stackprof/stackprof.so
 *.sw?

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,7 @@ end
 require 'rake/extensiontask'
 Rake::ExtensionTask.new('stackprof', GEMSPEC) do |ext|
   ext.ext_dir = 'ext'
+  ext.lib_dir = 'lib/stackprof'
 end
 task :build => :compile
 

--- a/ext/stackprof.c
+++ b/ext/stackprof.c
@@ -540,8 +540,5 @@ Init_stackprof(void)
     rb_define_singleton_method(rb_mStackProf, "results", stackprof_results, -1);
     rb_define_singleton_method(rb_mStackProf, "sample", stackprof_sample, 0);
 
-    rb_autoload(rb_mStackProf, rb_intern_const("Report"), "stackprof/report.rb");
-    rb_autoload(rb_mStackProf, rb_intern_const("Middleware"), "stackprof/middleware.rb");
-
     pthread_atfork(stackprof_atfork_prepare, stackprof_atfork_parent, stackprof_atfork_child);
 }

--- a/lib/stackprof.rb
+++ b/lib/stackprof.rb
@@ -1,0 +1,4 @@
+require "stackprof/stackprof"
+
+StackProf.autoload :Report, "stackprof/report.rb"
+StackProf.autoload :Middleware, "stackprof/middleware.rb"


### PR DESCRIPTION
`rb_autoload` is deprecated by r52909 (from Ruby 2.3).
Change `rb_autoload` of C function to `autoload` of
Ruby method.

cf: https://github.com/ruby/ruby/commit/a2e025a7d05047a75c749f64ea7819a4540bb3d3