### PR TITLE
Adds "--walk", for interactive mode for the stackprof bin

### DIFF
--- a/bin/stackprof
+++ b/bin/stackprof
@@ -12,7 +12,8 @@ parser = OptionParser.new(ARGV) do |o|
   o.on('--limit [num]', Integer, 'Limit --text, --files, or --graphviz output to N entries'){ |n| options[:limit] = n }
   o.on('--sort-total', "Sort --text or --files output on total samples\n\n"){ options[:sort] = true }
   o.on('--method [grep]', 'Zoom into specified method'){ |f| options[:format] = :method; options[:filter] = f }
-  o.on('--file [grep]', "Show annotated code for specified file\n\n"){ |f| options[:format] = :file; options[:filter] = f }
+  o.on('--file [grep]', "Show annotated code for specified file"){ |f| options[:format] = :file; options[:filter] = f }
+  o.on('--walk', "Walk the stacktrace interactively\n\n"){ |f| options[:walk] = true }
   o.on('--callgrind', 'Callgrind output (use with kcachegrind, stackprof-gprof2dot.py)'){ options[:format] = :callgrind }
   o.on('--graphviz', "Graphviz output (use with dot)"){ options[:format] = :graphviz }
   o.on('--node-fraction [frac]', OptionParser::DecimalNumeric, 'Drop nodes representing less than [frac] fraction of samples'){ |n| options[:node_fraction] = n }
@@ -74,7 +75,7 @@ when :stackcollapse
 when :flamegraph
   report.print_flamegraph
 when :method
-  report.print_method(options[:filter])
+  options[:walk] ? report.walk_method(options[:filter]) : report.print_method(options[:filter])
 when :file
   report.print_file(options[:filter])
 when :files


### PR DESCRIPTION
First off, thanks for this wonderful tool.  It has become and invaluable tool in my arsenal and has saved me a bunch of time.

But there is one problem... all the copy-pasta I have to do when I want to traverse to the next caller/callee in the stack is very error prone (I have fat fingers... geez), and having to wait for stackprof re-parse the json dump file every time I traverse to tree is _**The Worst**_™ when dealing with a sample size of 30K+ (not really, its actually still pretty snappy, but work with me here).

Yeah, sure, I could use one of them fancy-pants web UIs for stackprof to visualize the tree, but I'm a terminal junky... I don't need one of them stinking browsers to view my stacktrace.

Enter the :sparkles:`--walk`:sparkles: flag (with an obnoxious and over the top intro...)
## Overview

Snarky (and probably not that funny) intro aside, this basically adds a single method, `#walk_method`, to the `Stackprof::Report` class which essentially a while loop around `print_method`.  During each iteration of the loop, it runs `#print_method` for the current `name`, and ask the user which "caller" or "callee" from that they wish to traverse to next.  Rinse and repeat until the user exits.

This allows following the stack up from a given method, usually in a lib/gem, up to the caller in the application, or even from the application down into the gem (if that happens to be useful), all without having to reload the frames.

Few things of note that I didn't implement (but considered):
- I used `STDOUT.puts` and `STDIN.gets` instead of the shorthand only because you were doing it with a given `IO` object in the other methods in the class (usually called `f`).  I decided to stick with being explicit instead of dropping down to the short hand, even though this method doesn't make sense being used with anything besides `STDIN`/`STDOUT`.  I can switch to the shorthand if you prefer.
- Getting the current frame and callers/callees from that frame are ripped off completely from what you did in `print_method`, which leads to two things:
  - I considered pulling those out into separate private methods to avoid the code duplication, but decided to wait on that to get feedback if this is something that is wanted in the project.
  - Since this is just re-looping through the frames again (something that is already done in the `print_method`), I was wondering if the return value for the `print_method` should be the matched frames, and possibly the parsed callers/callees.  Probably not terribly worth the effort, since the frames are already in memory and re-parsing them is quick, just something I noticed.
- The README and help text could probably be a little more specific when describing where and when the `--walk` flag can be used (only has an effect currently when used in conjunction with the `--method` flag) so some work could be done there.
- I considered also doubling up the flags and including the `-i` (for "interactive") flag along side the `--walk` flag since that is a common one, but the executable seems to be using long-form command line flags exclusively, so I decided to pass on that.
## Basic Usage

Basically, when using the `stackprof` executable with the `--method` flag, also include the `--walk` flag, and it will jump into using the `#walk_method` instead of the `#print_method`.

```
$ stackprof example.dump --method Foo#bar --walk
```

If you feel like this is a bit out of scope for the project, I have no problem building a third-party commandline tool since this would be easily extendible with the existing `Stackprof::Report` interface.  But I thought I would first contribute here in case you thought it made sense to be included in the core project.

Thanks again for `stackprof`!
