### PR TITLE
Speed up Report#print_flamegraph

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -9,7 +9,8 @@ module StackProf
     attr_reader :data
 
     def frames(sort_by_total=false)
-      @data[:frames].sort_by{ |iseq, stats| -stats[sort_by_total ? :total_samples : :samples] }.inject({}){|h, (k, v)| h[k] = v; h}
+      @data[:"sorted_frames_#{sort_by_total}"] ||=
+        @data[:frames].sort_by{ |iseq, stats| -stats[sort_by_total ? :total_samples : :samples] }.inject({}){|h, (k, v)| h[k] = v; h}
     end
 
     def normalized_frames


### PR DESCRIPTION
We were re-sorting `@data[:frames]` for every row of the flamegraph. Now `Report#frames` is memoized so the sorting only happens once.

```shellsession
$ cat bench.rb
require "benchmark"
require "stackprof"

report = StackProf::Report.new(Marshal.load(IO.binread(ARGV[0])))

puts Benchmark.measure { report.print_flamegraph(StringIO.new) }
$ wc -c stackprof.dump
2079095 stackprof.dump
# Before
$ bundle exec ruby bench.rb stackprof.dump
 13.980000   0.150000  14.130000 ( 14.167130)
# After
$ bundle exec ruby bench.rb stackprof.dump
  0.370000   0.000000   0.370000 (  0.371662)
```

/cc @tmm1 