### PR TITLE
Travis: rely on defaults in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
+sudo: false
 language: ruby
 rvm:
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
   - ruby-head
-script: "bundle exec rake test"
-sudo: false


### PR DESCRIPTION
This PR changes the .travis.yml to rely more on its defaults.

  - the default script for "ruby" is `bundle exec rake` - and the `default` task in Rakefile is aliased to "test"
  - bump the versions to their [latest ruby-build patch versions](https://github.com/rbenv/ruby-build/tree/master/share/ruby-build)