### PR TITLE
Fix sample.rb

### DIFF
--- a/sample.rb
+++ b/sample.rb
@@ -24,9 +24,9 @@ class A
   end
 end
 
-#profile = StackProf.run(:object, 1) do
-#profile = StackProf.run(:wall, 1000) do
-profile = StackProf.run(:cpu, 1000) do
+#profile = StackProf.run(mode: :object, interval: 1) do
+#profile = StackProf.run(mode: :wall, interval: 1000) do
+profile = StackProf.run(mode: :cpu, interval: 1000) do
   1_000_000.times do
     A.new
   end


### PR DESCRIPTION
`StackProf.run` requires only keyword arguments.

## before

```
sample.rb:29:in `run': wrong number of arguments (given 2, expected 0) (ArgumentError)
	from sample.rb:29:in `<main>'
```
