### PR TITLE
Add documentation for `save_every` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Option      | Meaning
 `interval`  | mode-relative sample rate [c.f.](#sampling)
 `aggregate` | defaults: `true` - if `false` disables [aggregation](#aggregation)
 `raw`       | defaults `false` - if `true` collects the extra data required by the `--flamegraph` and `--stackcollapse` report types
+`save_every`| (rack middleware only) write the target file after this many requests
 
 ### todo
 


### PR DESCRIPTION
Thought this option meant seconds and was really confused why my single 100+ second upload request wasn't ever writing a dump file! :)