### PR TITLE
Add fake stack frames representing samples taken during garbage collection

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -552,6 +552,7 @@ Init_stackprof(void)
 #undef S
 
     gc_hook = Data_Wrap_Struct(rb_cObject, stackprof_gc_mark, NULL, &_stackprof);
+    rb_global_variable(&gc_hook);
 
     _stackprof.fake_gc_frame = rb_str_new_literal("fake_gc_frame");
     _stackprof.empty_string = rb_str_new_literal("");

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -366,7 +366,7 @@ stackprof_record_sample_for_stack(int num)
 	    _stackprof.raw_samples = malloc(sizeof(VALUE) * _stackprof.raw_samples_capa);
 	}
 
-	if (_stackprof.raw_samples_capa <= _stackprof.raw_samples_len + num) {
+	while (_stackprof.raw_samples_capa <= _stackprof.raw_samples_len + (num + 2)) {
 	    _stackprof.raw_samples_capa *= 2;
 	    _stackprof.raw_samples = realloc(_stackprof.raw_samples, sizeof(VALUE) * _stackprof.raw_samples_capa);
 	}

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -44,6 +44,8 @@ static struct {
     st_table *frames;
 
     VALUE fake_gc_frame;
+    VALUE fake_gc_frame_name;
+    VALUE empty_string;
     VALUE frames_buffer[BUF_SIZE];
     int lines_buffer[BUF_SIZE];
 } _stackprof;
@@ -189,8 +191,8 @@ frame_i(st_data_t key, st_data_t val, st_data_t arg)
     rb_hash_aset(results, rb_obj_id(frame), details);
 
     if (frame == _stackprof.fake_gc_frame) {
-	name = rb_str_new_literal("(garbage collection)");
-	file = rb_str_new_literal("");
+	name = _stackprof.fake_gc_frame_name;
+	file = _stackprof.empty_string;
 	line = INT2FIX(0);
     } else {
 	name = rb_profile_frame_full_label(frame);
@@ -550,8 +552,13 @@ Init_stackprof(void)
 #undef S
 
     gc_hook = Data_Wrap_Struct(rb_cObject, stackprof_gc_mark, NULL, &_stackprof);
+
     _stackprof.fake_gc_frame = rb_str_new_literal("fake_gc_frame");
-    rb_global_variable(&gc_hook);
+    _stackprof.empty_string = rb_str_new_literal("");
+    _stackprof.fake_gc_frame_name = rb_str_new_literal("(garbage collection)");
+    rb_global_variable(&_stackprof.fake_gc_frame);
+    rb_global_variable(&_stackprof.fake_gc_frame_name);
+    rb_global_variable(&_stackprof.empty_string);
 
     rb_mStackProf = rb_define_module("StackProf");
     rb_define_singleton_method(rb_mStackProf, "running?", stackprof_running_p, 0);

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -579,8 +579,8 @@ Init_stackprof(void)
     rb_global_variable(&gc_hook);
 
     _stackprof.fake_gc_frame = INT2FIX(0x9C);
-    _stackprof.empty_string = rb_str_new_literal("");
-    _stackprof.fake_gc_frame_name = rb_str_new_literal("(garbage collection)");
+    _stackprof.empty_string = rb_str_new_cstr("");
+    _stackprof.fake_gc_frame_name = rb_str_new_cstr("(garbage collection)");
     rb_global_variable(&_stackprof.fake_gc_frame_name);
     rb_global_variable(&_stackprof.empty_string);
 

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -120,13 +120,14 @@ class StackProfTest < MiniTest::Test
   end
 
   def test_gc
-    profile = StackProf.run(interval: 100) do
+    profile = StackProf.run(interval: 100, raw: true) do
       5.times do
         GC.start
       end
     end
 
-    assert_empty profile[:frames]
+    raw = profile[:raw]
+    assert_equal profile[:frames][raw[1]][:name], '(garbage collection)'
     assert_operator profile[:gc_samples], :>, 0
     assert_equal 0, profile[:missed_samples]
   end


### PR DESCRIPTION
When we attempt to take a sample during a garbage collection, instead of just incrementing a counter, we can include a sample in the `raw` output corresponding to a fake stake frame indicating that we're in the middle of a garbage collection. In this case, we include a fake name of `(garbage collection)` and an empty file name.

Fixes #86 