### PR TITLE
Include timestamp deltas to get more accurate sample timings

### DIFF
--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -105,6 +105,7 @@ class StackProfTest < MiniTest::Test
     assert_equal 10, raw[-1]
     assert_equal raw[0] + 2, raw.size
     assert_includes profile[:frames][raw[-2]][:name], 'StackProfTest#test_raw'
+    assert_equal 10, profile[:raw_timestamp_deltas].size
   end
 
   def test_fork


### PR DESCRIPTION
This includes a new field in the report output when `raw: true` is set.

The field `:raw_timestamp_deltas` indicates the amount of elapsed time in microseconds since the previous sample occurred. This allows us to match up wall time measurements with the sampling profiler.

Fixes #88