### PR TITLE
[#94] fix default use of filename in middleware and allow `out` option

### DIFF
--- a/test/test_middleware.rb
+++ b/test/test_middleware.rb
@@ -9,7 +9,7 @@ class StackProf::MiddlewareTest < MiniTest::Test
   def test_path_default
     StackProf::Middleware.new(Object.new)
 
-    assert_equal 'tmp', StackProf::Middleware.path
+    assert_equal 'tmp/', StackProf::Middleware.path
   end
 
   def test_path_custom

--- a/test/test_middleware.rb
+++ b/test/test_middleware.rb
@@ -13,27 +13,27 @@ class StackProf::MiddlewareTest < MiniTest::Test
   end
 
   def test_path_custom
-    StackProf::Middleware.new(Object.new, { path: '/foo' })
+    StackProf::Middleware.new(Object.new, { path: 'foo/' })
 
-    assert_equal '/foo', StackProf::Middleware.path
+    assert_equal 'foo/', StackProf::Middleware.path
   end
 
   def test_save_default
     StackProf::Middleware.new(Object.new)
 
     StackProf.stubs(:results).returns({ mode: 'foo' })
-    FileUtils.expects(:mkdir_p).with('tmp')
+    FileUtils.expects(:mkdir_p).with('tmp/')
     File.expects(:open).with(regexp_matches(/^tmp\/stackprof-foo/), 'wb')
 
     StackProf::Middleware.save
   end
 
   def test_save_custom
-    StackProf::Middleware.new(Object.new, { path: '/foo' })
+    StackProf::Middleware.new(Object.new, { path: 'foo/' })
 
     StackProf.stubs(:results).returns({ mode: 'foo' })
-    FileUtils.expects(:mkdir_p).with('/foo')
-    File.expects(:open).with(regexp_matches(/^\/foo\/stackprof-foo/), 'wb')
+    FileUtils.expects(:mkdir_p).with('foo/')
+    File.expects(:open).with(regexp_matches(/^foo\/stackprof-foo/), 'wb')
 
     StackProf::Middleware.save
   end


### PR DESCRIPTION
Previously, it wasn't possible to pass filename in middleware call and make it override default. Also, the `out:` option available in Ruby wasn't available to the middleware. This PR fixes the former and adds the latter.