### PR TITLE
Eliminate one loop over the stack by using `overall_samples`

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -20,7 +20,7 @@
 typedef struct {
     size_t total_samples;
     size_t caller_samples;
-    int already_accounted_in_total;
+    size_t seen_at_sample_number;
     st_table *edges;
     st_table *lines;
 } frame_data_t;
@@ -434,18 +434,14 @@ stackprof_record_sample_for_stack(int num, int timestamp_delta)
     }
 
     for (i = 0; i < num; i++) {
-	VALUE frame = _stackprof.frames_buffer[i];
-	sample_for(frame)->already_accounted_in_total = 0;
-    }
-
-    for (i = 0; i < num; i++) {
 	int line = _stackprof.lines_buffer[i];
 	VALUE frame = _stackprof.frames_buffer[i];
 	frame_data_t *frame_data = sample_for(frame);
 
-	if (!frame_data->already_accounted_in_total)
+	if (frame_data->seen_at_sample_number != _stackprof.overall_samples) {
 	    frame_data->total_samples++;
-	frame_data->already_accounted_in_total = 1;
+	}
+	frame_data->seen_at_sample_number = _stackprof.overall_samples;
 
 	if (i == 0) {
 	    frame_data->caller_samples++;

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -119,6 +119,27 @@ class StackProfTest < MiniTest::Test
     end
   end
 
+  def foo(n = 10)
+    if n == 0
+      StackProf.sample
+      return
+    end
+    foo(n - 1)
+  end
+
+  def test_recursive_total_samples
+    profile = StackProf.run(mode: :cpu, raw: true) do
+      10.times do
+        foo
+      end
+    end
+
+    frame = profile[:frames].values.find do |frame|
+      frame[:name] == "StackProfTest#foo"
+    end
+    assert_equal 10, frame[:total_samples]
+  end
+
   def test_gc
     profile = StackProf.run(interval: 100, raw: true) do
       5.times do


### PR DESCRIPTION
Previously, the `already_accounted_in_total` member on the
`frame_data_t` struct was used to keep track of whether or not a
particular frame had been seen in a stack.  For example, a recursive
function is only supposed to count the frame once in the `total_samples`
member.

Instead of using the `already_accounted_in_total` as a flag, this commit
uses the `overall_samples` value as a unique identifier for the frame.
`overall_samples` will be different on every call to
`stackprof_record_sample_for_stack`, but the value will stay the same
for the duration of that function.  That means we can use the value to
indicate whether or not a particular frame has been "seen" and
we can eliminate one loop over the stack.