### PR TITLE
Remove /ext from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 /lib/stackprof/stackprof.bundle
 /lib/stackprof/stackprof.so
 *.sw?
-/ext
 /pkg


### PR DESCRIPTION
The /ext directory contains source code and ignoring this directory causes eg Atom to not render it in its tree view. Perhaps specific build artifacts should be ignored in place of the entire directory?