### PR TITLE
Allow Pathname objects for Stackprof :out

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -312,7 +312,13 @@ stackprof_results(int argc, VALUE *argv, VALUE self)
 	if (RB_TYPE_P(_stackprof.out, T_STRING)) {
 	    file = rb_file_open_str(_stackprof.out, "w");
 	} else {
-	    file = rb_io_check_io(_stackprof.out);
+	    ID pathname_id = rb_intern("Pathname");
+	    if (rb_const_defined(rb_cObject, pathname_id) && 
+		    rb_obj_is_kind_of(_stackprof.out, rb_const_get(rb_cObject, pathname_id)) == Qtrue) {
+		file = rb_file_open_str(rb_funcall(_stackprof.out, rb_intern("to_s"), 0), "w");
+	    } else {
+		file = rb_io_check_io(_stackprof.out);
+	    }
 	}
 	rb_marshal_dump(results, file);
 	rb_io_flush(file);

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -2,6 +2,7 @@ $:.unshift File.expand_path('../../lib', __FILE__)
 require 'stackprof'
 require 'minitest/autorun'
 require 'tempfile'
+require 'pathname'
 
 class StackProfTest < MiniTest::Test
   def test_info
@@ -162,6 +163,19 @@ class StackProfTest < MiniTest::Test
     end
 
     assert_equal tmpfile, ret
+    tmpfile.rewind
+    profile = Marshal.load(tmpfile.read)
+    refute_empty profile[:frames]
+  end
+
+  def test_pathname_out
+    tmpfile  = Tempfile.new('stackprof-out')
+    pathname = Pathname.new(tmpfile.path)
+    ret = StackProf.run(mode: :custom, out: pathname) do
+      StackProf.sample
+    end
+
+    assert_equal tmpfile.path, ret.path
     tmpfile.rewind
     profile = Marshal.load(tmpfile.read)
     refute_empty profile[:frames]


### PR DESCRIPTION
The code for `stackprof_results` currently only does checks to see if the VALUE for `_stackprof.out` is a `T_STRING`, otherwise it assumes it is an IO object.

This updates the code to first check if `Pathname` has been required and defined.  If it is and the `_stackprof.out` is a `Pathname`, then open a file in the same manner as if it was a string, but calls `.to_s` to convert it to a ruby string first.

Fixes #79