### PR TITLE
Add --json format

### DIFF
--- a/bin/stackprof
+++ b/bin/stackprof
@@ -8,6 +8,7 @@ parser = OptionParser.new(ARGV) do |o|
   o.banner = "Usage: stackprof [file.dump]+ [--text|--method=NAME|--callgrind|--graphviz]"
 
   o.on('--text', 'Text summary per method (default)'){ options[:format] = :text }
+  o.on('--json', 'JSON output (use with web viewers)'){ options[:format] = :json }
   o.on('--files', 'List of files'){ |f| options[:format] = :files }
   o.on('--limit [num]', Integer, 'Limit --text, --files, or --graphviz output to N entries'){ |n| options[:limit] = n }
   o.on('--sort-total', "Sort --text or --files output on total samples\n\n"){ options[:sort] = true }
@@ -62,6 +63,8 @@ options.delete(:limit) if options[:limit] == 0
 case options[:format]
 when :text
   report.print_text(options[:sort], options[:limit], options[:select_files], options[:reject_files], options[:select_names], options[:reject_names])
+when :json
+  report.print_json
 when :debug
   report.print_debug
 when :dump

--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -68,6 +68,11 @@ module StackProf
       f.puts Marshal.dump(@data.reject{|k,v| k == :files })
     end
 
+    def print_json(f=STDOUT)
+      require "json"
+      f.puts JSON.generate(@data)
+    end
+
     def print_stackcollapse
       raise "profile does not include raw samples (add `raw: true` to collecting StackProf.run)" unless raw = data[:raw]
 


### PR DESCRIPTION
Add `--json` output to `stack prof` CLI.

The generated output could be used with web viewers (e.g. I want to use it with 
https://www.speedscope.app/ – yeah, I've noticed that there is a [PR](#100) to add out-of-the-box speedscope support; but who knows which flame graph viewer will rock in a year or two?).

