### PR TITLE
fixed assigned but unused var warnings

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -42,7 +42,7 @@ module StackProf
     end
 
     def files
-      @data[:files] ||= @data[:frames].inject(Hash.new) do |hash, (addr, frame)|
+      @data[:files] ||= @data[:frames].inject(Hash.new) do |hash, (_addr, frame)|
         if file = frame[:file] and lines = frame[:lines]
           hash[file] ||= Hash.new
           lines.each do |line, weight|

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -148,7 +148,6 @@ class StackProfTest < MiniTest::Test
       end
     end
 
-    raw = profile[:raw]
     gc_frame = profile[:frames].values.find{ |f| f[:name] == "(garbage collection)" }
     assert gc_frame
     assert_equal gc_frame[:samples], profile[:gc_samples]


### PR DESCRIPTION
When I run test my envrionement, some warnings occured.
This PR fixed this warnings.

```
install -c tmp/x86_64-darwin18/stackprof/2.6.1/stackprof.bundle lib/stackprof/stackprof.bundle
cp tmp/x86_64-darwin18/stackprof/2.6.1/stackprof.bundle tmp/x86_64-darwin18/stage/lib/stackprof/stackprof.bundle
/Users/yoshimin/src/github.com/tmm1/stackprof/test/test_stackprof.rb:151: warning: assigned but unused variable - raw
Run options: --seed 43865

# Running:

....................../Users/yoshimin/src/github.com/tmm1/stackprof/lib/stackprof/report.rb:45: warning: assigned but unused variable - addr
..

Finished in 0.307169s, 78.1329 runs/s, 244.1653 assertions/s.
24 runs, 75 assertions, 0 failures, 0 errors, 0 skips
```