### PR TITLE
Fix missed samples stat in object mode

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -46,6 +46,7 @@ static struct {
 
     size_t overall_signals;
     size_t overall_samples;
+    size_t newobj_signals;
     size_t during_gc;
     size_t unrecorded_gc_samples;
     st_table *frames;
@@ -96,6 +97,7 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
 	_stackprof.frames = st_init_numtable();
 	_stackprof.overall_signals = 0;
 	_stackprof.overall_samples = 0;
+	_stackprof.newobj_signals = 0;
 	_stackprof.during_gc = 0;
     }
 
@@ -572,9 +574,10 @@ stackprof_signal_handler(int sig, siginfo_t *sinfo, void *ucontext)
 static void
 stackprof_newobj_handler(VALUE tpval, void *data)
 {
-    _stackprof.overall_signals++;
-    if (RTEST(_stackprof.interval) && _stackprof.overall_signals % NUM2LONG(_stackprof.interval))
+    _stackprof.newobj_signals++;
+    if (RTEST(_stackprof.interval) && _stackprof.newobj_signals % NUM2LONG(_stackprof.interval))
 	return;
+    _stackprof.overall_signals++;
     stackprof_job_handler(0);
 }
 

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -58,6 +58,14 @@ class StackProfTest < MiniTest::Test
     assert_equal 10, profile[:samples]
   end
 
+  def test_object_allocation_missed_samples
+    profile = StackProf.run(mode: :object, interval: 100) do
+      1000.times { Object.new }
+    end
+    assert_equal 10, profile[:samples]
+    assert_equal 0, profile[:missed_samples]
+  end
+
   def test_cputime
     profile = StackProf.run(mode: :cpu, interval: 500) do
       math


### PR DESCRIPTION
### Problem

When profiling in `object` mode, the sample miss rate is incorrectly calculated. `overall_signals` is incremented every time a new object is allocated, however we only want to capture a sample every `interval`. This all but guarantees a miss rate of > 99% when profiling in `object` mode, which isn't accurate.

### Solution

Add a new member to the `_stackprof` struct, `newobj_signals`, that we can use to track the number of allocations. If it's determined that we should capture a sample, _then_ increment the `overall_signals` member. This should make the miss rate accurate again.