### PR TITLE
Implement Report#merge for efficiently combining many reports

### DIFF
--- a/test/test_report.rb
+++ b/test/test_report.rb
@@ -26,19 +26,68 @@ class ReportTest < MiniTest::Test
     assert_dump data, f.string
   end
 
-  def test_add
-    p1 = StackProf.run(mode: :cpu, raw: true) do
-      foo
-    end
-    p2 = StackProf.run(mode: :cpu, raw: true) do
-      foo
-      bar
+  def test_merge
+    data = [
+      StackProf.run(mode: :cpu, raw: true) do
+        foo
+      end,
+      StackProf.run(mode: :cpu, raw: true) do
+        foo
+        bar
+      end,
+      StackProf.run(mode: :cpu, raw: true) do
+        foo
+        bar
+        baz
+      end
+    ]
+    expectations = {
+      foo: {
+        total_samples: 3,
+        samples: 3,
+        total_lines: 1,
+      },
+      bar: {
+        total_samples: 4,
+        samples: 2,
+        total_lines: 2,
+        has_boz_edge: true
+      },
+      baz: {
+        total_samples: 2,
+        samples: 1,
+        total_lines: 2,
+        has_boz_edge: true,
+      },
+      boz: {
+        total_samples: 3,
+        samples: 3,
+        total_lines: 1,
+      },
+    }
+
+    reports = data.map {|d| StackProf::Report.new(d)}
+    combined = reports[0].merge(*reports[1..-1])
+
+    frames = expectations.keys.inject(Hash.new) do |hash, key|
+      hash[key] = find_method_frame(combined, key)
+      hash
     end
 
-    combined = StackProf::Report.new(p1) + StackProf::Report.new(p2)
+    expectations.each do |key, expect|
+      frame = frames[key]
+      assert_equal expect[:total_samples], frame[:total_samples], key
+      assert_equal expect[:samples], frame[:samples], key
 
-    assert_equal 2, find_method_frame(combined, :foo)[:total_samples]
-    assert_equal 1, find_method_frame(combined, :bar)[:total_samples]
+      assert_equal expect[:total_lines], frame[:lines].length, key
+      assert_includes frame[:lines], frame[:line] + 1, key
+      assert_equal [expect[:samples], expect[:samples]], frame[:lines][frame[:line] + 1], key
+
+      if expect[:has_boz_edge]
+        assert_equal ({frames[:boz][:hash] => expect[:samples]}), frame[:edges]
+      end
+    end
+
   end
 
   private
@@ -54,6 +103,16 @@ class ReportTest < MiniTest::Test
   end
 
   def bar
+    StackProf.sample
+    boz
+  end
+
+  def baz
+    StackProf.sample
+    boz
+  end
+
+  def boz
     StackProf.sample
   end
 

--- a/test/test_report.rb
+++ b/test/test_report.rb
@@ -2,7 +2,7 @@ $:.unshift File.expand_path('../../lib', __FILE__)
 require 'stackprof'
 require 'minitest/autorun'
 
-class ReportDumpTest < MiniTest::Test
+class ReportTest < MiniTest::Test
   require 'stringio'
 
   def test_dump_to_stdout
@@ -26,7 +26,36 @@ class ReportDumpTest < MiniTest::Test
     assert_dump data, f.string
   end
 
+  def test_add
+    p1 = StackProf.run(mode: :cpu, raw: true) do
+      foo
+    end
+    p2 = StackProf.run(mode: :cpu, raw: true) do
+      foo
+      bar
+    end
+
+    combined = StackProf::Report.new(p1) + StackProf::Report.new(p2)
+
+    assert_equal 2, find_method_frame(combined, :foo)[:total_samples]
+    assert_equal 1, find_method_frame(combined, :bar)[:total_samples]
+  end
+
   private
+
+  def find_method_frame(profile, name)
+    profile.frames.values.find do |frame|
+      frame[:name] == "ReportTest##{name}"
+    end
+  end
+
+  def foo
+    StackProf.sample
+  end
+
+  def bar
+    StackProf.sample
+  end
 
   def assert_dump(expected, marshal_data)
     assert_equal expected, Marshal.load(marshal_data)


### PR DESCRIPTION
I need to combine 40 large profiles collected from a CI run. `Report#+` gets very slow as I merge more reports (e.g. with `reports.inject(:+)`). This PR implements `Report#merge` that allows for merging an arbitrary number of reports in a single pass. It also implements a test for the merge behavior.