### PR TITLE
Add `--alphabetical-flamegraph` for population-based instead of timeline

### DIFF
--- a/bin/stackprof
+++ b/bin/stackprof
@@ -19,7 +19,9 @@ parser = OptionParser.new(ARGV) do |o|
   o.on('--graphviz', "Graphviz output (use with dot)"){ options[:format] = :graphviz }
   o.on('--node-fraction [frac]', OptionParser::DecimalNumeric, 'Drop nodes representing less than [frac] fraction of samples'){ |n| options[:node_fraction] = n }
   o.on('--stackcollapse', 'stackcollapse.pl compatible output (use with stackprof-flamegraph.pl)'){ options[:format] = :stackcollapse }
-  o.on('--flamegraph', "timeline-flamegraph output (js)"){ options[:format] = :flamegraph }
+  o.on('--timeline-flamegraph', "timeline-flamegraph output (js)"){ options[:format] = :timeline_flamegraph }
+  o.on('--alphabetical-flamegraph', "alphabetical-flamegraph output (js)"){ options[:format] = :alphabetical_flamegraph }
+  o.on('--flamegraph', "alias to --timeline-flamegraph"){ options[:format] = :timeline_flamegraph }
   o.on('--flamegraph-viewer [f.js]', String, "open html viewer for flamegraph output\n\n"){ |file|
     puts("open file://#{File.expand_path('../../lib/stackprof/flamegraph/viewer.html', __FILE__)}?data=#{File.expand_path(file)}")
     exit
@@ -75,8 +77,10 @@ when :graphviz
   report.print_graphviz(options)
 when :stackcollapse
   report.print_stackcollapse
-when :flamegraph
-  report.print_flamegraph
+when :timeline_flamegraph
+  report.print_timeline_flamegraph
+when :alphabetical_flamegraph
+  report.print_alphabetical_flamegraph
 when :method
   options[:walk] ? report.walk_method(options[:filter]) : report.print_method(options[:filter])
 when :file

--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -85,7 +85,15 @@ module StackProf
       end
     end
 
-    def print_flamegraph(f=STDOUT, skip_common=true)
+    def print_timeline_flamegraph(f=STDOUT, skip_common=true)
+      print_flamegraph(f, skip_common, false)
+    end
+
+    def print_alphabetical_flamegraph(f=STDOUT, skip_common=true)
+      print_flamegraph(f, skip_common, true)
+    end
+
+    def print_flamegraph(f, skip_common, alphabetical=false)
       raise "profile does not include raw samples (add `raw: true` to collecting StackProf.run)" unless raw = data[:raw]
 
       stacks = []
@@ -97,6 +105,8 @@ module StackProf
         stacks << stack
         max_x += stack.last
       end
+
+      stacks.sort! if alphabetical
 
       f.puts 'flamegraph(['
       max_y.times do |y|


### PR DESCRIPTION
The current flamegraph of stackprof is often chopped because it puts the
passage of time on the x-axis.

This change adds `--alphabetical-flamegraph` mode which sorts the stack
traces in alphabetical order.  This view is much easier than the current
one for understanding bottlenecks.

Also, `--timeline-flamegraph` is added for consistency, and the original
`--flamegraph` option is the same effect as `--timeline-flamegraph` (for
compatibility reason).