### PR TITLE
Use docker for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,22 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
-  - 2.5
-  - ruby-head
+sudo: required
+
+services:
+  - docker
+
+language: general
+
+env:
+  matrix:
+    - RVM_RUBY_VERSION=2.1
+    - RVM_RUBY_VERSION=2.2
+    - RVM_RUBY_VERSION=2.3
+    - RVM_RUBY_VERSION=2.4
+    - RVM_RUBY_VERSION=2.5
+    - RVM_RUBY_VERSION=2.6
+    - RVM_RUBY_VERSION=ruby-head
+
+before_install:
+- sudo docker build -t stackprof-$RVM_RUBY_VERSION --build-arg=RVM_RUBY_VERSION=$RVM_RUBY_VERSION .
+
+script:
+- sudo docker run --name stackprof-$RVM_RUBY_VERSION stackprof-$RVM_RUBY_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:16.04
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -q && \
+    apt-get install -qy \
+      curl ca-certificates gnupg2 dirmngr build-essential \
+      gawk git autoconf automake pkg-config \
+      bison libffi-dev libgdbm-dev libncurses5-dev libsqlite3-dev libtool \
+      libyaml-dev sqlite3 zlib1g-dev libgmp-dev libreadline-dev libssl-dev \
+      ruby --no-install-recommends && \
+    apt-get clean
+
+RUN gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN curl -sSL https://get.rvm.io | bash -s
+ARG RVM_RUBY_VERSION=ruby-head
+RUN /bin/bash -l -c "echo $RVM_RUBY_VERSION"
+RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && rvm install $RVM_RUBY_VERSION --binary || rvm install $RVM_RUBY_VERSION"
+ADD . /stackprof/
+WORKDIR /stackprof/
+RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && gem install bundler:1.16.0"
+RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && bundle install"
+CMD /bin/bash -l -c ". /etc/profile.d/rvm.sh && bundle exec rake"


### PR DESCRIPTION
"rvm install ruby-head" gets stuck on travis for unknown reason.
For example: https://travis-ci.org/tmm1/stackprof/builds/585472791

Using docker takes more time (about 30s -> 2m30s), but the environment
is reproducible on local machines, and it works actually.

In addition, this adds Ruby 2.6 to the matrix.