### PR TITLE
Add optional IO arg for .print_stackcollapse

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -73,15 +73,15 @@ module StackProf
       f.puts JSON.generate(@data, max_nesting: false)
     end
 
-    def print_stackcollapse
+    def print_stackcollapse(f=STDOUT)
       raise "profile does not include raw samples (add `raw: true` to collecting StackProf.run)" unless raw = data[:raw]
 
       while len = raw.shift
         frames = raw.slice!(0, len)
         weight = raw.shift
 
-        print frames.map{ |a| data[:frames][a][:name] }.join(';')
-        puts " #{weight}"
+        f.print frames.map{ |a| data[:frames][a][:name] }.join(';')
+        f.puts " #{weight}"
       end
     end
 


### PR DESCRIPTION
Like the other methods in the class, it allows for choosing a IO object to have the data written to.  This can allow for writing to a IO object in the current ruby process and then processing it in the same process without having to do crazy `STDOUT` constant overwriting to achieve it.