### PR TITLE
Rake tasks for running tests in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .ruby-version
+Gemfile.lock

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - RVM_RUBY_VERSION=ruby-head
 
 before_install:
+- sudo --help
 - sudo -E which ruby
 - sudo -E which rake
 - sudo -E rake --trace test:docker:$RVM_RUBY_VERSION:build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 services:
   - docker
 
-language: general
+language: ruby
 
 env:
   matrix:
@@ -15,7 +15,7 @@ env:
     - RVM_RUBY_VERSION=ruby-head
 
 before_install:
-- sudo docker build -t stackprof-$RVM_RUBY_VERSION --build-arg=RVM_RUBY_VERSION=$RVM_RUBY_VERSION .
+- sudo rake test:docker:$RVM_RUBY_VERSION:build
 
 script:
-- sudo docker run --name stackprof-$RVM_RUBY_VERSION stackprof-$RVM_RUBY_VERSION
+- sudo rake test:docker:$RVM_RUBY_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - RVM_RUBY_VERSION=ruby-head
 
 before_install:
-- sudo -E rake test:docker:$RVM_RUBY_VERSION:build
+- sudo -E rake --trace test:docker:$RVM_RUBY_VERSION:build
 
 script:
-- sudo -E rake test:docker:$RVM_RUBY_VERSION
+- sudo -E rake --trace test:docker:$RVM_RUBY_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
     - RVM_RUBY_VERSION=ruby-head
 
 before_install:
+- sudo -E which ruby
+- sudo -E which rake
 - sudo -E rake --trace test:docker:$RVM_RUBY_VERSION:build
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,8 @@ env:
     - RVM_RUBY_VERSION=2.6
     - RVM_RUBY_VERSION=ruby-head
 
-before_install:
-- sudo --help
-- sudo -i which ruby
-- sudo -i which rake
-- bundle install
-- rake --trace test:docker:$RVM_RUBY_VERSION:build
+after_install:
+- bundle exec rake test:docker:$RVM_RUBY_VERSION:build
 
 script:
-- rake --trace test:docker:$RVM_RUBY_VERSION
+- bundle exec rake test:docker:$RVM_RUBY_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 - sudo --help
 - sudo -i which ruby
 - sudo -i which rake
+- bundle install
 - rake --trace test:docker:$RVM_RUBY_VERSION:build
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 - sudo --help
 - sudo -i which ruby
 - sudo -i which rake
-- sudo -i rake --trace test:docker:$RVM_RUBY_VERSION:build
+- rake --trace test:docker:$RVM_RUBY_VERSION:build
 
 script:
-- sudo -i rake --trace test:docker:$RVM_RUBY_VERSION
+- rake --trace test:docker:$RVM_RUBY_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ env:
 
 before_install:
 - sudo --help
-- sudo -E which ruby
-- sudo -E which rake
-- sudo -E rake --trace test:docker:$RVM_RUBY_VERSION:build
+- sudo -i which ruby
+- sudo -i which rake
+- sudo -i rake --trace test:docker:$RVM_RUBY_VERSION:build
 
 script:
-- sudo -E rake --trace test:docker:$RVM_RUBY_VERSION
+- sudo -i rake --trace test:docker:$RVM_RUBY_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - RVM_RUBY_VERSION=ruby-head
 
 before_install:
-- sudo rake test:docker:$RVM_RUBY_VERSION:build
+- sudo -E rake test:docker:$RVM_RUBY_VERSION:build
 
 script:
-- sudo rake test:docker:$RVM_RUBY_VERSION
+- sudo -E rake test:docker:$RVM_RUBY_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ ADD . /stackprof/
 WORKDIR /stackprof/
 RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && gem install bundler:1.16.0"
 RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && bundle install"
+RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && bundle exec rake build"
 CMD /bin/bash -l -c ". /etc/profile.d/rvm.sh && bundle exec rake"

--- a/Rakefile
+++ b/Rakefile
@@ -14,11 +14,16 @@ end
 # Ruby Extension
 # ==========================================================
 
-require 'rake/extensiontask'
-Rake::ExtensionTask.new('stackprof', GEMSPEC) do |ext|
-  ext.lib_dir = 'lib/stackprof'
+begin
+  require 'rake/extensiontask'
+  Rake::ExtensionTask.new('stackprof', GEMSPEC) do |ext|
+    ext.lib_dir = 'lib/stackprof'
+  end
+  task :build => :compile
+rescue LoadError => e
+  # rake-compiler not installed.  No problem if on CI.
+  raise e unless ENV["TRAVIS"]
 end
-task :build => :compile
 
 # ==========================================================
 # Testing

--- a/Rakefile
+++ b/Rakefile
@@ -29,3 +29,58 @@ Rake::TestTask.new 'test' do |t|
   t.test_files = FileList['test/test_*.rb']
 end
 task :test => :build
+
+def build_ruby_docker_image ruby_version = "ruby-head"
+  image   = "stackprof-#{ruby_version}"
+  sh_opts = []
+  sh_opts = [{[:out, :err] => File::NULL}, {}] if @mute_build_output
+
+  puts "\033[34m==>\033[0m \033[1mBuilding Docker Image for #{ruby_version}...\033[0m"
+  sh "docker build -t #{image} --build-arg=RVM_RUBY_VERSION=#{ruby_version} .", *sh_opts
+end
+
+def run_tests_in_docker ruby_version = "ruby-head"
+  sh "docker run --rm stackprof-#{ruby_version}"
+end
+
+namespace :test do
+  namespace :docker do
+    RUBY_VERSIONS = %w[2.1 2.2 2.3 2.4 2.5]
+
+    RUBY_VERSIONS.each do |ruby_version|
+      task "#{ruby_version}:build" do
+        build_ruby_docker_image ruby_version
+      end
+
+      desc "Run tests in docker for Ruby #{ruby_version}"
+      task ruby_version => "#{ruby_version}:build" do
+        run_tests_in_docker ruby_version
+      end
+    end
+
+    task "ruby-head:build" do
+      run_tests_in_docker
+    end
+
+    desc "Run tests in docker for ruby-head"
+    task "ruby-head" => "ruby-head:build" do
+      run_tests_in_docker
+    end
+
+    desc "Run tests in docker for all versions"
+    task :all => %w[mute_build_output] + RUBY_VERSIONS + %w[ruby-head]
+
+    desc "Clean created docker images"
+    task :clean do
+      images  = RUBY_VERSIONS.map {|rbv| "stackprof-#{rbv}" }
+      images << "stackprof-ruby-head"
+      sh "docker rmi --force #{images.join(' ')}", {[:out,:err] => File::NULL}
+    end
+
+    task :mute_build_output do
+      @mute_build_output = true
+    end
+  end
+
+  task :docker => "test:docker:all"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,7 @@ end
 
 namespace :test do
   namespace :docker do
-    RUBY_VERSIONS = %w[2.1 2.2 2.3 2.4 2.5 2.6]
+    RUBY_VERSIONS = %w[2.2 2.3 2.4 2.5 2.6]
 
     RUBY_VERSIONS.each do |ruby_version|
       task "#{ruby_version}:build" do

--- a/Rakefile
+++ b/Rakefile
@@ -64,7 +64,7 @@ namespace :test do
     end
 
     task "ruby-head:build" do
-      run_tests_in_docker
+      build_ruby_docker_image
     end
 
     desc "Run tests in docker for ruby-head"

--- a/Rakefile
+++ b/Rakefile
@@ -14,16 +14,11 @@ end
 # Ruby Extension
 # ==========================================================
 
-begin
-  require 'rake/extensiontask'
-  Rake::ExtensionTask.new('stackprof', GEMSPEC) do |ext|
-    ext.lib_dir = 'lib/stackprof'
-  end
-  task :build => :compile
-rescue LoadError => e
-  # rake-compiler not installed.  No problem if on CI.
-  raise e unless ENV["TRAVIS"]
+require 'rake/extensiontask'
+Rake::ExtensionTask.new('stackprof', GEMSPEC) do |ext|
+  ext.lib_dir = 'lib/stackprof'
 end
+task :build => :compile
 
 # ==========================================================
 # Testing

--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ end
 
 namespace :test do
   namespace :docker do
-    RUBY_VERSIONS = %w[2.1 2.2 2.3 2.4 2.5]
+    RUBY_VERSIONS = %w[2.1 2.2 2.3 2.4 2.5 2.6]
 
     RUBY_VERSIONS.each do |ruby_version|
       task "#{ruby_version}:build" do

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ Rake::TestTask.new 'test' do |t|
 end
 task :test => :build
 
-def build_ruby_docker_image ruby_version = "ruby-head"
+def build_ruby_docker_image(ruby_version="ruby-head")
   image   = "stackprof-#{ruby_version}"
   sh_opts = []
   sh_opts = [{[:out, :err] => File::NULL}, {}] if @mute_build_output
@@ -39,7 +39,7 @@ def build_ruby_docker_image ruby_version = "ruby-head"
   sh "docker build -t #{image} --build-arg=RVM_RUBY_VERSION=#{ruby_version} .", *sh_opts
 end
 
-def run_tests_in_docker ruby_version = "ruby-head"
+def run_tests_in_docker(ruby_version="ruby-head")
   sh "docker run --rm stackprof-#{ruby_version}"
 end
 


### PR DESCRIPTION
This is a set of helper rake tasks are intended to make running tests locally in docker much streamline and simpler to pick up as a new-comer to the project.

Requires a `docker` environment available in your shell environment.


Quick Start
-----------

To simply run the rake tasks, you can run:

```console
$ rake test:docker
```

To specify a specific target ruby version:

```console
$ rake test:docker:2.1
```


@mame Curious about your thoughts on this one since you recently did the work https://github.com/tmm1/stackprof/pull/116 to start running tests on travis with `docker`.