### PR TITLE
Fix timestamp math: 1 million microseconds per second

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -16,6 +16,7 @@
 #include <pthread.h>
 
 #define BUF_SIZE 2048
+#define MICROSECONDS_IN_SECOND 1000000
 
 typedef struct {
     size_t total_samples;
@@ -497,7 +498,7 @@ stackprof_record_sample()
 	struct timeval diff;
 	gettimeofday(&t, NULL);
 	timersub(&t, &_stackprof.last_sample_at, &diff);
-	timestamp_delta = (1000 * diff.tv_sec) + diff.tv_usec;
+	timestamp_delta = (MICROSECONDS_IN_SECOND * diff.tv_sec) + diff.tv_usec;
     }
     num = rb_profile_frames(0, sizeof(_stackprof.frames_buffer) / sizeof(VALUE), _stackprof.frames_buffer, _stackprof.lines_buffer);
     stackprof_record_sample_for_stack(num, timestamp_delta);
@@ -516,7 +517,7 @@ stackprof_record_gc_samples()
 
 	// We don't know when the GC samples were actually marked, so let's
 	// assume that they were marked at a perfectly regular interval.
-	delta_to_first_unrecorded_gc_sample = (1000 * diff.tv_sec + diff.tv_usec) - (_stackprof.unrecorded_gc_samples - 1) * NUM2LONG(_stackprof.interval);
+	delta_to_first_unrecorded_gc_sample = (MICROSECONDS_IN_SECOND * diff.tv_sec + diff.tv_usec) - (_stackprof.unrecorded_gc_samples - 1) * NUM2LONG(_stackprof.interval);
 	if (delta_to_first_unrecorded_gc_sample < 0) {
 	    delta_to_first_unrecorded_gc_sample = 0;
 	}


### PR DESCRIPTION
There appears to be a bug in the way `timeval`s are handled in `raw_timestamp_deltas`: `tv_sec` (seconds) is multiplied by 1000 (milliseconds) and then added to `tv_usec` (microseconds).

https://www.gnu.org/software/libc/manual/html_node/Elapsed-Time.html says,
> `time_t tv_sec`
> This represents the number of whole *seconds* of elapsed time.
> `long int tv_usec`
>
> This is the rest of the elapsed time (a fraction of a second), represented as the number of **microseconds**. It is always less than one million.

and of course, https://en.wikipedia.org/wiki/Microsecond,
> A microsecond is an SI unit of time equal to one millionth (0.000001 or 10−6 or ​1⁄1,000,000) of a second.

Playing with this in a [C repl](https://repl.it/repls/WearableUnlinedProtools) confirms this behavior.

I'm not entirely sure what the implication of this bug is.
- Let's say the sampling `interval` is 1000 (microseconds), i.e. 1 millisecond. `timestamp_delta` in `stackprof_record_sample` should always have a `tv_sec` value of 0. So `1000 * 0` is 0 and it doesn't matter.
- But if the sampling rate was much higher, let's say 5 seconds and 100 milliseconds (`tv_sec=5, tv_usec=100`), then `timestamp_delta = (1000 * 5) + 100 = 5,100`, but it should be `timestamp_delta = (1000000 * 5) + 100 = 5,000,100`. Whether the _seconds_ part itself being 1/1000 of the correct value, though, might not matter if they're all proportionately downscaled. (I don't fully understand how `raw_timestamp_deltas` is ultimately used.) But the microsecond amount skews the total 1000x more than it should.

Thank you