### PR TITLE
Prevent hanging when sample collection time > interval

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -546,7 +546,7 @@ void
 stackprof_record_gc_samples()
 {
     int64_t delta_to_first_unrecorded_gc_sample = 0;
-    int i;
+    unsigned long i;
     struct timeval t;
     struct timeval diff;
     gettimeofday(&t, NULL);
@@ -565,7 +565,7 @@ stackprof_record_gc_samples()
     _stackprof.lines_buffer[0] = 0;
 
     for (i = 0; i < _stackprof.unrecorded_gc_samples; i++) {
-	int timestamp_delta = i == 0 ? delta_to_first_unrecorded_gc_sample : NUM2INT(_stackprof.interval);
+	int64_t timestamp_delta = i == 0 ? delta_to_first_unrecorded_gc_sample : NUM2INT(_stackprof.interval);
 	stackprof_record_sample_for_stack(1, timestamp_delta);
     }
     _stackprof.during_gc += _stackprof.unrecorded_gc_samples;

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -132,11 +132,6 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
 	timer.it_interval.tv_usec = NUM2INT(interval);
 	timer.it_value = timer.it_interval;
 	setitimer(mode == sym_wall ? ITIMER_REAL : ITIMER_PROF, &timer, 0);
-
-        if (_stackprof.debug) {
-            printf("started with interval %d (%ld sec %d usec)\n",
-                NUM2INT(interval), timer.it_interval.tv_sec, timer.it_interval.tv_usec);
-        }
     } else if (mode == sym_custom) {
 	/* sampled manually */
 	interval = Qnil;
@@ -150,6 +145,11 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
     _stackprof.mode = mode;
     _stackprof.interval = interval;
     _stackprof.out = out;
+
+    if (_stackprof.debug) {
+        printf("started with interval %d (%ld sec %d usec)\n",
+            NUM2INT(_stackprof.interval), timer.it_interval.tv_sec, timer.it_interval.tv_usec);
+    }
 
     return Qtrue;
 }

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -386,7 +386,7 @@ st_numtable_increment(st_table *table, st_data_t key, size_t increment)
 }
 
 void
-stackprof_record_sample_for_stack(int num, int timestamp_delta)
+stackprof_record_sample_for_stack(int frame_count, int timestamp_delta)
 {
     int i, n;
     VALUE prev_frame = Qnil;
@@ -402,29 +402,29 @@ stackprof_record_sample_for_stack(int num, int timestamp_delta)
 	int found = 0;
 
 	/* If there's no sample buffer allocated, then allocate one.  The buffer
-	 * format is the number of frames (num), then the list of frames (from
+	 * format is the number of frames (frame_count), then the list of frames (from
 	 * `_stackprof.raw_samples`), followed by the number of times this
 	 * particular stack has been seen in a row.  Each "new" stack is added
 	 * to the end of the buffer, but if the previous stack is the same as
 	 * the current stack, the counter will be incremented. */
 	if (!_stackprof.raw_samples) {
-	    _stackprof.raw_samples_capa = num * 100;
+	    _stackprof.raw_samples_capa = frame_count * 100;
 	    _stackprof.raw_samples = malloc(sizeof(VALUE) * _stackprof.raw_samples_capa);
 	}
 
 	/* If we can't fit all the samples in the buffer, double the buffer size. */
-	while (_stackprof.raw_samples_capa <= _stackprof.raw_samples_len + (num + 2)) {
+	while (_stackprof.raw_samples_capa <= _stackprof.raw_samples_len + (frame_count + 2)) {
 	    _stackprof.raw_samples_capa *= 2;
 	    _stackprof.raw_samples = realloc(_stackprof.raw_samples, sizeof(VALUE) * _stackprof.raw_samples_capa);
 	}
 
 	/* If we've seen this stack before in the last sample, then increment the "seen" count. */
-	if (_stackprof.raw_samples_len > 0 && _stackprof.raw_samples[_stackprof.raw_sample_index] == (VALUE)num) {
+	if (_stackprof.raw_samples_len > 0 && _stackprof.raw_samples[_stackprof.raw_sample_index] == (VALUE)frame_count) {
 	    /* The number of samples could have been the same, but the stack
 	     * might be different, so we need to check the stack here.  Stacks
 	     * in the raw buffer are stored in the opposite direction of stacks
 	     * in the frames buffer that came from Ruby. */
-	    for (i = num-1, n = 0; i >= 0; i--, n++) {
+	    for (i = frame_count-1, n = 0; i >= 0; i--, n++) {
 		VALUE frame = _stackprof.frames_buffer[i];
 		if (_stackprof.raw_samples[_stackprof.raw_sample_index + 1 + n] != frame)
 		    break;
@@ -441,8 +441,8 @@ stackprof_record_sample_for_stack(int num, int timestamp_delta)
 	    /* Bump the `raw_sample_index` up so that the next iteration can
 	     * find the previously recorded stack size. */
 	    _stackprof.raw_sample_index = _stackprof.raw_samples_len;
-	    _stackprof.raw_samples[_stackprof.raw_samples_len++] = (VALUE)num;
-	    for (i = num-1; i >= 0; i--) {
+	    _stackprof.raw_samples[_stackprof.raw_samples_len++] = (VALUE)frame_count;
+	    for (i = frame_count-1; i >= 0; i--) {
 		VALUE frame = _stackprof.frames_buffer[i];
 		_stackprof.raw_samples[_stackprof.raw_samples_len++] = frame;
 	    }
@@ -466,7 +466,7 @@ stackprof_record_sample_for_stack(int num, int timestamp_delta)
 	_stackprof.raw_timestamp_deltas[_stackprof.raw_timestamp_deltas_len++] = timestamp_delta;
     }
 
-    for (i = 0; i < num; i++) {
+    for (i = 0; i < frame_count; i++) {
 	int line = _stackprof.lines_buffer[i];
 	VALUE frame = _stackprof.frames_buffer[i];
 	frame_data_t *frame_data = sample_for(frame);
@@ -519,7 +519,7 @@ void
 stackprof_record_sample()
 {
     int timestamp_delta = 0;
-    int num;
+    int frame_count;
     if (_stackprof.raw) {
 	struct timeval t;
 	struct timeval diff;
@@ -527,8 +527,8 @@ stackprof_record_sample()
 	timersub(&t, &_stackprof.last_sample_at, &diff);
 	timestamp_delta = stackprof_timeval_to_usec(&diff);
     }
-    num = rb_profile_frames(0, sizeof(_stackprof.frames_buffer) / sizeof(VALUE), _stackprof.frames_buffer, _stackprof.lines_buffer);
-    stackprof_record_sample_for_stack(num, timestamp_delta);
+    frame_count = rb_profile_frames(0, sizeof(_stackprof.frames_buffer) / sizeof(VALUE), _stackprof.frames_buffer, _stackprof.lines_buffer);
+    stackprof_record_sample_for_stack(frame_count, timestamp_delta);
 }
 
 void

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -103,11 +103,13 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
 
     if (!RTEST(mode)) mode = sym_wall;
 
+    // profiling can be paused and resumed, so allow for existing frames
     if (!_stackprof.frames) {
 	_stackprof.frames = st_init_numtable();
 	_stackprof.overall_signals = 0;
 	_stackprof.overall_samples = 0;
 	_stackprof.during_gc = 0;
+        _stackprof.in_signal_handler = 0;
     }
 
     if (mode == sym_object) {
@@ -140,7 +142,6 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
     _stackprof.mode = mode;
     _stackprof.interval = interval;
     _stackprof.out = out;
-    _stackprof.in_signal_handler = 0;
 
     gettimeofday(&_stackprof.started_at, NULL);
     _stackprof.last_sample_at = _stackprof.started_at;

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -17,6 +17,7 @@
 #include <stdint.h>
 
 #define BUF_SIZE 2048
+#define MICROSECONDS_IN_SECOND 1000000
 
 typedef struct {
     size_t total_samples;

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -86,6 +86,8 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
     if (_stackprof.running)
 	return Qfalse;
 
+    gettimeofday(&_stackprof.started_at, NULL);
+
     rb_scan_args(argc, argv, "0:", &opts);
 
     if (RTEST(opts)) {
@@ -110,6 +112,7 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
 	_stackprof.overall_samples = 0;
 	_stackprof.during_gc = 0;
 	_stackprof.in_signal_handler = 0;
+	_stackprof.last_sample_at = _stackprof.started_at;
     }
 
     if (mode == sym_object) {
@@ -142,9 +145,6 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
     _stackprof.mode = mode;
     _stackprof.interval = interval;
     _stackprof.out = out;
-
-    gettimeofday(&_stackprof.started_at, NULL);
-    _stackprof.last_sample_at = _stackprof.started_at;
 
     return Qtrue;
 }

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -385,6 +385,11 @@ st_numtable_increment(st_table *table, st_data_t key, size_t increment)
     st_update(table, key, numtable_increment_callback, (st_data_t)increment);
 }
 
+/*
+    Records information about the frames captured in `_stackprof.frames_buffer`,
+    up to `frame_count-1` (buffer may contain more frames from prior sample),
+    captured `timestamp_delta` microseconds after previous sample.
+*/
 void
 stackprof_record_sample_for_stack(int frame_count, int timestamp_delta)
 {

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -45,7 +45,7 @@ static struct {
 
     struct timeval started_at;
     struct timeval last_sample_at;
-    int *raw_timestamp_deltas;
+    int64_t *raw_timestamp_deltas;
     size_t raw_timestamp_deltas_len;
     size_t raw_timestamp_deltas_capa;
 
@@ -309,7 +309,7 @@ stackprof_results(int argc, VALUE *argv, VALUE self)
 	raw_timestamp_deltas = rb_ary_new_capa(_stackprof.raw_timestamp_deltas_len);
 
 	for (n = 0; n < _stackprof.raw_timestamp_deltas_len; n++) {
-	    rb_ary_push(raw_timestamp_deltas, INT2FIX(_stackprof.raw_timestamp_deltas[n]));
+	    rb_ary_push(raw_timestamp_deltas, LL2NUM(_stackprof.raw_timestamp_deltas[n]));
 	}
 
 	free(_stackprof.raw_timestamp_deltas);
@@ -462,14 +462,14 @@ stackprof_record_sample_for_stack(int frame_count, int64_t timestamp_delta)
 	/* If there's no timestamp delta buffer, allocate one */
 	if (!_stackprof.raw_timestamp_deltas) {
 	    _stackprof.raw_timestamp_deltas_capa = 100;
-	    _stackprof.raw_timestamp_deltas = malloc(sizeof(int) * _stackprof.raw_timestamp_deltas_capa);
+	    _stackprof.raw_timestamp_deltas = malloc(sizeof(int64_t) * _stackprof.raw_timestamp_deltas_capa);
 	    _stackprof.raw_timestamp_deltas_len = 0;
 	}
 
 	/* Double the buffer size if it's too small */
 	while (_stackprof.raw_timestamp_deltas_capa <= _stackprof.raw_timestamp_deltas_len + 1) {
 	    _stackprof.raw_timestamp_deltas_capa *= 2;
-	    _stackprof.raw_timestamp_deltas = realloc(_stackprof.raw_timestamp_deltas, sizeof(int) * _stackprof.raw_timestamp_deltas_capa);
+	    _stackprof.raw_timestamp_deltas = realloc(_stackprof.raw_timestamp_deltas, sizeof(int64_t) * _stackprof.raw_timestamp_deltas_capa);
 	}
 
 	/* Store the time delta (which is the amount of time between samples) */

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -109,7 +109,7 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
 	_stackprof.overall_signals = 0;
 	_stackprof.overall_samples = 0;
 	_stackprof.during_gc = 0;
-        _stackprof.in_signal_handler = 0;
+	_stackprof.in_signal_handler = 0;
     }
 
     if (mode == sym_object) {
@@ -169,7 +169,7 @@ stackprof_stop(VALUE self)
 	sa.sa_flags = SA_RESTART;
 	sigemptyset(&sa.sa_mask);
 	sigaction(_stackprof.mode == sym_wall ? SIGALRM : SIGPROF, &sa, NULL);
-        _stackprof.in_signal_handler = 0;
+	_stackprof.in_signal_handler = 0;
     } else if (_stackprof.mode == sym_custom) {
 	/* sampled manually */
     } else {

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -45,7 +45,7 @@ static struct {
 
     struct timeval started_at;
     struct timeval last_sample_at;
-    int *raw_timestamp_deltas;
+    int64_t *raw_timestamp_deltas;
     size_t raw_timestamp_deltas_len;
     size_t raw_timestamp_deltas_capa;
 
@@ -129,9 +129,14 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
 	sigaction(mode == sym_wall ? SIGALRM : SIGPROF, &sa, NULL);
 
 	timer.it_interval.tv_sec = 0;
-	timer.it_interval.tv_usec = NUM2LONG(interval);
+	timer.it_interval.tv_usec = NUM2INT(interval);
 	timer.it_value = timer.it_interval;
 	setitimer(mode == sym_wall ? ITIMER_REAL : ITIMER_PROF, &timer, 0);
+
+        if (_stackprof.debug) {
+            printf("started with interval %d (%ld sec %d usec)\n",
+                NUM2INT(interval), timer.it_interval.tv_sec, timer.it_interval.tv_usec);
+        }
     } else if (mode == sym_custom) {
 	/* sampled manually */
 	interval = Qnil;
@@ -396,7 +401,7 @@ st_numtable_increment(st_table *table, st_data_t key, size_t increment)
     captured `timestamp_delta` microseconds after previous sample.
 */
 void
-stackprof_record_sample_for_stack(int frame_count, int timestamp_delta)
+stackprof_record_sample_for_stack(int frame_count, int64_t timestamp_delta)
 {
     int i, n;
     VALUE prev_frame = Qnil;
@@ -514,10 +519,8 @@ stackprof_record_sample()
 
     if (_stackprof.debug) {
         int64_t time_since_start_usec = diff_timevals_usec(&_stackprof.started_at, &sampling_start);
-        printf("timestamp delta %ld usec since last, %ld since start, with interval %ld\n",
-            time_since_last_sample_usec,
-            time_since_start_usec,
-            NUM2LONG(_stackprof.interval));
+        printf("timestamp delta %lld usec since last, %lld since start, with interval %d\n",
+            time_since_last_sample_usec, time_since_start_usec, NUM2INT(_stackprof.interval));
     }
 
     frame_count = rb_profile_frames(0, sizeof(_stackprof.frames_buffer) / sizeof(VALUE), _stackprof.frames_buffer, _stackprof.lines_buffer);
@@ -531,12 +534,11 @@ stackprof_record_sample()
         int64_t sampling_duration_usec = diff_timevals_usec(&sampling_start, &sampling_finish);
         printf("duration of stackprof_record_sample: %ld usec with interval %d\n",
             sampling_duration_usec,
-            NUM2LONG(_stackprof.interval));
+            NUM2INT(_stackprof.interval));
 
-        if (sampling_duration_usec >= NUM2LONG(_stackprof.interval)) {
+        if (sampling_duration_usec >= NUM2INT(_stackprof.interval)) {
             fprintf(stderr, "INTERVAL IS TOO FAST: %d with interval %d\n",
-                sampling_duration_usec,
-                NUM2LONG(_stackprof.interval));
+                sampling_duration_usec, NUM2INT(_stackprof.interval));
         }
     }
 }
@@ -544,7 +546,7 @@ stackprof_record_sample()
 void
 stackprof_record_gc_samples()
 {
-    int delta_to_first_unrecorded_gc_sample = 0;
+    int64_t delta_to_first_unrecorded_gc_sample = 0;
     int i;
     struct timeval t;
     struct timeval diff;
@@ -554,7 +556,7 @@ stackprof_record_gc_samples()
     if (_stackprof.raw) {
 	// We don't know when the GC samples were actually marked, so let's
 	// assume that they were marked at a perfectly regular interval.
-	delta_to_first_unrecorded_gc_sample = timeval_to_usec(&diff) - (_stackprof.unrecorded_gc_samples - 1) * NUM2LONG(_stackprof.interval);
+	delta_to_first_unrecorded_gc_sample = timeval_to_usec(&diff) - (_stackprof.unrecorded_gc_samples - 1) * NUM2INT(_stackprof.interval);
 	if (delta_to_first_unrecorded_gc_sample < 0) {
 	    delta_to_first_unrecorded_gc_sample = 0;
 	}
@@ -564,7 +566,7 @@ stackprof_record_gc_samples()
     _stackprof.lines_buffer[0] = 0;
 
     for (i = 0; i < _stackprof.unrecorded_gc_samples; i++) {
-	int timestamp_delta = i == 0 ? delta_to_first_unrecorded_gc_sample : NUM2LONG(_stackprof.interval);
+	int64_t timestamp_delta = i == 0 ? delta_to_first_unrecorded_gc_sample : NUM2INT(_stackprof.interval);
 	stackprof_record_sample_for_stack(1, timestamp_delta);
     }
     _stackprof.during_gc += _stackprof.unrecorded_gc_samples;
@@ -619,7 +621,7 @@ static void
 stackprof_newobj_handler(VALUE tpval, void *data)
 {
     _stackprof.overall_signals++;
-    if (RTEST(_stackprof.interval) && _stackprof.overall_signals % NUM2LONG(_stackprof.interval))
+    if (RTEST(_stackprof.interval) && _stackprof.overall_signals % NUM2INT(_stackprof.interval))
 	return;
     stackprof_job_handler(0);
 }
@@ -671,8 +673,9 @@ stackprof_atfork_parent(void)
     struct itimerval timer;
     if (_stackprof.running) {
 	if (_stackprof.mode == sym_wall || _stackprof.mode == sym_cpu) {
+	    // TODO what if interval > 1 sec ??
 	    timer.it_interval.tv_sec = 0;
-	    timer.it_interval.tv_usec = NUM2LONG(_stackprof.interval);
+	    timer.it_interval.tv_usec = NUM2INT(_stackprof.interval);
 	    timer.it_value = timer.it_interval;
 	    setitimer(_stackprof.mode == sym_wall ? ITIMER_REAL : ITIMER_PROF, &timer, 0);
 	}

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -196,13 +196,13 @@ class StackProfTest < MiniTest::Test
   end
 
   def test_wall_too_fast_no_hang
-    # The stack of `recurse` takes longer than 1μs to sample
+    # The stack of `recurse` takes longer than 10μs to sample
     # (probabilistically on a current CPU),
     # so if this was not handled properly, the job queue would pile up
     # faster than it was flushed, and the program would hang.
     # Timeout ensures that if this is broken, the test itself does not hang.
     results = Timeout.timeout(10) do
-      StackProf.run(mode: :wall, interval: 1) { recurse }
+      StackProf.run(mode: :wall, interval: 10) { recurse }
     end
     # Program can use this to infer that sampling rate was too high
     assert_operator results[:missed_samples], :>, 0

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -3,6 +3,7 @@ require 'stackprof'
 require 'minitest/autorun'
 require 'tempfile'
 require 'pathname'
+require 'timeout'
 
 class StackProfTest < MiniTest::Test
   def test_info
@@ -194,6 +195,16 @@ class StackProfTest < MiniTest::Test
     refute_empty profile[:frames]
   end
 
+  def test_wall_too_fast_no_hang
+    # The stack of `recurse` takes longer than 10μs to sample,
+    # so if this was not handled properly, the job queue would pile up
+    # faster than it was flushed, and the program would hang.
+    # Timeout ensures that if this is broken, the test itself does not hang.
+    Timeout.timeout(10) do
+      StackProf.run(mode: :wall, interval: 10) { recurse }
+    end
+  end
+
   def math
     250_000.times do
       2 ** 10
@@ -206,5 +217,13 @@ class StackProfTest < MiniTest::Test
   ensure
     r.close
     w.close
+  end
+
+  def recurse(num = 1, depth = 1)
+    if depth == 10000
+      num
+    else
+      recurse(num * 2, depth + 1)
+    end
   end
 end

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -196,13 +196,16 @@ class StackProfTest < MiniTest::Test
   end
 
   def test_wall_too_fast_no_hang
-    # The stack of `recurse` takes longer than 10μs to sample,
+    # The stack of `recurse` takes longer than 1μs to sample
+    # (probabilistically on a current CPU),
     # so if this was not handled properly, the job queue would pile up
     # faster than it was flushed, and the program would hang.
     # Timeout ensures that if this is broken, the test itself does not hang.
-    Timeout.timeout(10) do
-      StackProf.run(mode: :wall, interval: 10) { recurse }
+    results = Timeout.timeout(10) do
+      StackProf.run(mode: :wall, interval: 1) { recurse }
     end
+    # Program can use this to infer that sampling rate was too high
+    assert_operator results[:missed_samples], :>, 0
   end
 
   def math


### PR DESCRIPTION
This attempts to fix the bug described in #123, in which, when `interval` is faster than the time required to record and analyze stack frames, the job queue piles up faster than it's flushed and the program hangs.

Pieces:
- Moves the `in_signal_handler` lock to the global `_stackprof` struct, and adds a check, and escape hatch, in `stackprof_signal_handler`.
- Adds a test which demonstrates the hanging behavior and the fix for it.
- Adds helpers `timeval_to_usec` and `diff_timevals_usec` for working with time durations more easily as `long int`s of microseconds, rather than `timeval` structs.
- Adds a `debug` mode with stdout+stderr output recording the internal timings and flow.
- Adds some comments and renames some variables for clarity.

More context on the underlying bug, and consideration of alternative approaches, is at https://github.com/tmm1/stackprof/issues/123.

Motivation: 
We would like to use StackProf on a large-scale Ruby application in production. The inability to set an interval that is both fast enough to produce useful data, and guaranteed to never hang the program, is a blocker to doing so.

Caveats:
- I am an amateur with C. It took a lot of trial and error with this code and https://repl.it/languages/c to get this working.
- I have not yet analyzed what the escape hatch in `stackprof_signal_handler` does to the quality of the final results. (At the end of the day, it's a kind of user or program error if the interval is so fast that the escape hatch is necessary. The question is how to deal with it.)
- I have mostly tested this with `wall` mode; I have not yet analyzed how this bug or fix work with `cpu` or `object` modes (though I suspect they're similar).

cc @NickLaMuro, thank you for your engagement with #123!