### PR TITLE
ArgumentError on interval <1 or >1m

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -16,6 +16,7 @@
 #include <pthread.h>
 
 #define BUF_SIZE 2048
+#define MICROSECONDS_IN_SECOND 1000000
 
 typedef struct {
     size_t total_samples;
@@ -91,6 +92,10 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
 	    aggregate = 0;
     }
     if (!RTEST(mode)) mode = sym_wall;
+
+    if (!NIL_P(interval) && (NUM2INT(interval) < 1 || NUM2INT(interval) >= MICROSECONDS_IN_SECOND)) {
+        rb_raise(rb_eArgError, "interval is a number of microseconds between 1 and 1 million");
+    }
 
     if (!_stackprof.frames) {
 	_stackprof.frames = st_init_numtable();

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -194,6 +194,15 @@ class StackProfTest < MiniTest::Test
     refute_empty profile[:frames]
   end
 
+  def test_min_max_interval
+    [-1, 0, 1_000_000, 1_000_001].each do |invalid_interval|
+      err = assert_raises(ArgumentError, "invalid interval #{invalid_interval}") do
+        StackProf.run(interval: invalid_interval, debug: true) {}
+      end
+      assert_match(/microseconds/, err.message)
+    end
+  end
+
   def math
     250_000.times do
       2 ** 10


### PR DESCRIPTION
This addresses https://github.com/tmm1/stackprof/issues/125, a bug and/or undefined behavior when `interval` is > 1 million, the number of microseconds in a second.

- raises `ArgumentError` with `interval >= 1000000`
- raises same `ArgumentError` with `interval < 1` because this is also invalid

An alternative would be to split `interval` into second and microsecond parts, but it's not clear that a sampling interval measured in _seconds_ would ever be useful. (Also, if that was a common use case, I presume this would have been fixed in that direction a long time ago.)