### PR TITLE
Support custom metadata option in stackprof

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Option      | Meaning
 `interval`  | mode-relative sample rate [c.f.](#sampling)
 `aggregate` | defaults: `true` - if `false` disables [aggregation](#aggregation)
 `raw`       | defaults `false` - if `true` collects the extra data required by the `--flamegraph` and `--stackcollapse` report types
+`metadata`  | defaults to `{}`. Must be a `Hash`. metadata associated with this profile
 `save_every`| (rack middleware only) write the target file after this many requests
 
 ## Todo

--- a/lib/stackprof/middleware.rb
+++ b/lib/stackprof/middleware.rb
@@ -13,12 +13,18 @@ module StackProf
       Middleware.enabled  = options[:enabled]
       options[:path]      = 'tmp/' if options[:path].to_s.empty?
       Middleware.path     = options[:path]
+      Middleware.metadata = options[:metadata] || {}
       at_exit{ Middleware.save } if options[:save_at_exit]
     end
 
     def call(env)
       enabled = Middleware.enabled?(env)
-      StackProf.start(mode: Middleware.mode, interval: Middleware.interval, raw: Middleware.raw) if enabled
+      StackProf.start(
+        mode:     Middleware.mode,
+        interval: Middleware.interval,
+        raw:      Middleware.raw,
+        metadata: Middleware.metadata,
+      ) if enabled
       @app.call(env)
     ensure
       if enabled
@@ -31,7 +37,7 @@ module StackProf
     end
 
     class << self
-      attr_accessor :enabled, :mode, :interval, :raw, :path
+      attr_accessor :enabled, :mode, :interval, :raw, :path, :metadata
 
       def enabled?(env)
         if enabled.respond_to?(:call)

--- a/test/test_middleware.rb
+++ b/test/test_middleware.rb
@@ -64,4 +64,10 @@ class StackProf::MiddlewareTest < MiniTest::Test
     StackProf::Middleware.new(Object.new, raw: true)
     assert StackProf::Middleware.raw
   end
+
+  def test_metadata
+    metadata = { key: 'value' }
+    StackProf::Middleware.new(Object.new, metadata: metadata)
+    assert_equal metadata, StackProf::Middleware.metadata
+  end
 end

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -109,6 +109,36 @@ class StackProfTest < MiniTest::Test
     assert_equal 10, profile[:raw_timestamp_deltas].size
   end
 
+  def test_metadata
+    metadata = {
+      path: '/foo/bar',
+      revision: '5c0b01f1522ae8c194510977ae29377296dd236b',
+    }
+    profile = StackProf.run(mode: :cpu, metadata: metadata) do
+      math
+    end
+
+    assert_equal metadata, profile[:metadata]
+  end
+
+  def test_empty_metadata
+    profile = StackProf.run(mode: :cpu) do
+      math
+    end
+
+    assert_equal({}, profile[:metadata])
+  end
+
+  def test_raises_if_metadata_is_not_a_hash
+    exception = assert_raises ArgumentError do
+      StackProf.run(mode: :cpu, metadata: 'foobar') do
+        math
+      end
+    end
+
+    assert_equal 'metadata should be a hash', exception.message
+  end
+
   def test_fork
     StackProf.run do
       pid = fork do


### PR DESCRIPTION
At the moment, there is lack of information about what we're profiling in the profiles themselves. This PR adds the ability to include custom metadata to each profile.

Note that the metadata for the profile can only be set through `stackprof_start` or `stackprof_run`. In the future, maybe we could include the ability to add more metadata when dumping the results through `stackprof_results`. I would imagine it to take in a custom hash, which will be merged with the hash that was supplied through `stackprof_start` or `stackprof_run`.

cc: @csfrancis @tenderlove @tmm1 
