### PR TITLE
Record GC marking and sweeping as fake frames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ language: general
 
 env:
   matrix:
-    - RVM_RUBY_VERSION=2.1
     - RVM_RUBY_VERSION=2.2
     - RVM_RUBY_VERSION=2.3
     - RVM_RUBY_VERSION=2.4

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Inspired heavily by [gperftools](https://code.google.com/p/gperftools/), and wri
 
 ## Requirements
 
-* Ruby 2.1+
+* Ruby 2.2+
 * Linux-based OS
 
 ## Getting Started

--- a/stackprof.gemspec
+++ b/stackprof.gemspec
@@ -14,8 +14,10 @@ Gem::Specification.new do |s|
   s.executables << 'stackprof-flamegraph.pl'
   s.executables << 'stackprof-gprof2dot.py'
 
-  s.summary = 'sampling callstack-profiler for ruby 2.1+'
+  s.summary = 'sampling callstack-profiler for ruby 2.2+'
   s.description = 'stackprof is a fast sampling profiler for ruby code, with cpu, wallclock and object allocation samplers.'
+
+  s.required_ruby_version = '>= 2.2'
 
   s.license = 'MIT'
 

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -180,8 +180,16 @@ class StackProfTest < MiniTest::Test
 
     raw = profile[:raw]
     gc_frame = profile[:frames].values.find{ |f| f[:name] == "(garbage collection)" }
+    marking_frame = profile[:frames].values.find{ |f| f[:name] == "(marking)" }
+    sweeping_frame = profile[:frames].values.find{ |f| f[:name] == "(sweeping)" }
+
     assert gc_frame
-    assert_equal gc_frame[:samples], profile[:gc_samples]
+    assert marking_frame
+    assert sweeping_frame
+
+    assert_equal gc_frame[:total_samples], profile[:gc_samples]
+    assert_equal profile[:gc_samples], [gc_frame, marking_frame, sweeping_frame].map{|x| x[:samples] }.inject(:+)
+
     assert_operator profile[:gc_samples], :>, 0
     assert_operator profile[:missed_samples], :<=, 10
   end


### PR DESCRIPTION

<img width="779" alt="Screen Shot 2019-12-05 at 14 13 12" src="https://user-images.githubusercontent.com/131752/70278953-2dc3cb80-176a-11ea-921a-efaa8709eb15.png">


This attempts to measure the states GC is in by recording fake frames of "(marking)" or "(sweeping)". Occasionally we also encounter the GC being in state :none, but this should be fairly rare and harmless (we record this as a GC frame but not part of mark or sweep).

We don't have the ability to record the exact time mark and sweep happens, so we just keep a counter of how many times we've encountered each state. We assume all the marking happens before all the sweeping.

cc @tenderlove