### PR TITLE
Mark the metadata object before the GC is invoked to prevent it from being garbage collected

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -284,6 +284,8 @@ stackprof_results(int argc, VALUE *argv, VALUE self)
     rb_hash_aset(results, sym_missed_samples, SIZET2NUM(_stackprof.overall_signals - _stackprof.overall_samples));
     rb_hash_aset(results, sym_metadata, _stackprof.metadata);
 
+    _stackprof.metadata = Qnil;
+
     frames = rb_hash_new();
     rb_hash_aset(results, sym_frames, frames);
     st_foreach(_stackprof.frames, frame_i, (st_data_t)frames);
@@ -653,6 +655,9 @@ frame_mark_i(st_data_t key, st_data_t val, st_data_t arg)
 static void
 stackprof_gc_mark(void *data)
 {
+    if (RTEST(_stackprof.metadata))
+	rb_gc_mark(_stackprof.metadata);
+
     if (RTEST(_stackprof.out))
 	rb_gc_mark(_stackprof.out);
 


### PR DESCRIPTION
Custom metadata support was introduced in https://github.com/tmm1/stackprof/pull/128.

At the moment, the Ruby process crashes with a segfault when `.start` is called without a metadata, and output is written to a file. When `.start` is called without a metadata, we will create an empty hash using `rb_hash_new`. However, if the GC gets invoked during the profiling session, it will collect that empty hash, resulting in a segfault when we attempt to write the results to file.

```
# Running:

[New Thread 0x1007 of process 32592]
[New Thread 0x1503 of process 32592]
[New Thread 0x2903 of process 32592]

Thread 2 received signal SIGSEGV, Segmentation fault.
0x000000010021d139 in method_entry_get (klass=4380029280, id=152, defined_class_ptr=0x7ffeefbfdad0) at ./vm_method.c:813
813             ent->class_serial == RCLASS_SERIAL(klass) &&
(gdb) bt
#0  0x000000010021d139 in method_entry_get (klass=4380029280, id=152, defined_class_ptr=0x7ffeefbfdad0) at ./vm_method.c:813
#1  0x000000010021eea0 in vm_respond_to (ec=0x100701db8, klass=152, obj=547503796, id=15601, priv=85061984) at ./vm_method.c:1991
#2  0x000000010021ec5e in rb_obj_respond_to (obj=4380029320, id=15601, priv=547503796) at ./vm_method.c:2041
#3  0x00000001000ebb6f in w_object (obj=4430364672, arg=0x98, limit=85062024) at marshal.c:731
#4  0x00000001000eeb48 in hash_each (key=<optimized out>, value=2628, arg=0x10511f188) at marshal.c:493
#5  0x00000001000b8bd2 in hash_ar_foreach_iter (key=4380029280, value=0, argp=<optimized out>, error=0) at hash.c:1136
#6  ar_foreach_check (hash=<optimized out>, arg=140732920749568, never=52, func=<optimized out>) at hash.c:786
#7  hash_foreach_call (arg=<optimized out>) at hash.c:1205
#8  0x0000000100097ac5 in rb_ensure (b_proc=0x20a23eb4, data1=15601, e_proc=<optimized out>, data2=<optimized out>) at eval.c:1076
#9  0x00000001000b8b12 in rb_hash_foreach (hash=8580, func=<optimized out>, farg=<optimized out>) at hash.c:1229
#10 0x00000001000ed3f8 in w_object (obj=2628, arg=0x98, limit=85062024) at marshal.c:892
#11 0x00000001000eb446 in rb_marshal_dump_limited (obj=15601, port=547503796, limit=-1) at marshal.c:1054
#12 0x000000010058939b in ?? ()
#13 0x00000001080203e8 in ?? ()
#14 0x0000000000000001 in ?? ()
#15 0x00007ffeefbfdf90 in ?? ()
#16 0x000000010811faf8 in ?? ()
#17 0x0000000000000001 in ?? ()
#18 0x0000000105892898 in ?? ()
#19 0x0000000100601ac0 in ?? ()
#20 0x00000001058927d0 in ?? ()
#21 0x00007ffeefbfe060 in ?? ()
#22 0x000000010022efc6 in vm_call_cfunc_with_frame (ec=0x105823718, reg_cfp=0x105823808, ci=0xffffffff00627243, calling=<optimized out>, cc=<optimized out>)
    at ./vm_insnhelper.c:1908
#23 vm_call_cfunc (ec=0x105823718, reg_cfp=0x105823808, calling=<optimized out>, ci=0xffffffff00627243, cc=<optimized out>) at ./vm_insnhelper.c:1924
Backtrace stopped: frame did not save the PC
(gdb) c
```

Note that `rb_marshal_dump_limited` gets called by `rb_marshal_dump` here: 
https://github.com/tmm1/stackprof/blob/a7017069082000e1239bcfddb08e706e21548f6f/ext/stackprof/stackprof.c#L343

### Steps to reproduce

The following code snippet crashes the Ruby process with a segfault. If we run it with `0.2.13`, it'll work fine.

```ruby
gem 'stackprof', '0.2.14'

require 'stackprof'
StackProf.run(mode: :cpu, out: 'tmp/stackprof-cpu.dump') do
  GC.start
end
```

### Solution

EDIT:
After addressing PR reviews, I've decided to invoke `rb_gc_mark` to mark that empty hash to prevent it from being garbage collected instead of using a global variable with the reasoning that the empty hash is only allocated once per profiling session, and allocating it is not significant performance-wise.

---

One way to fix this is to invoke `rb_gc_mark` to mark that empty hash to prevent it from being garbage collected. However, I chose to introduce a new variable (`empty_hash`) in the stackprof struct and make it a global variable in Ruby's GC through `rb_global_variable`. One immediate advantage to this is that we are only allocating the empty hash once whenever stackprof is loaded instead of once per profiling session. All variables registered as a global variable through `rb_global_variable` will be marked by the Ruby's GC, so we don't need to handle that in stackprof:

https://github.com/ruby/ruby/blob/95213f6df6a23918d57a743975708c638da42aae/gc.c#L5601-L5605

Note that we're already doing something similar for the empty string:
https://github.com/tmm1/stackprof/blob/a7017069082000e1239bcfddb08e706e21548f6f/ext/stackprof/stackprof.c#L742-L743

cc: @csfrancis @tenderlove 

Thanks @gmcgibbon for reporting this error! :smile: