### PR TITLE
Add option to ignore GC frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ StackProf.run(mode: :object, out: 'tmp/stackprof.dump', interval: 1) do
 end
 ```
 
+by default, samples taken during garbage collection will show as garbage collection frames
+including both mark and sweep phases. for longer traces, these can leave gaps in a flamegraph
+that are hard to follow and can be disabled by setting the `ignore_gc` option to true.
+garbage collection time will still be present in the profile but not explicitly marked with
+its own frame.
+
 samples are taken using a combination of three new C-APIs in ruby 2.1:
 
   - signal handlers enqueue a sampling job using `rb_postponed_job_register_one`.
@@ -328,6 +334,7 @@ Option      | Meaning
 `mode`      | mode of sampling: `:cpu`, `:wall`, `:object`, or `:custom` [c.f.](#sampling)
 `out`       | the target file, which will be overwritten
 `interval`  | mode-relative sample rate [c.f.](#sampling)
+`ignore_gc` | Ignore garbage collection frames
 `aggregate` | defaults: `true` - if `false` disables [aggregation](#aggregation)
 `raw`       | defaults `false` - if `true` collects the extra data required by the `--flamegraph` and `--stackcollapse` report types
 `metadata`  | defaults to `{}`. Must be a `Hash`. metadata associated with this profile

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -46,6 +46,7 @@ static struct {
     VALUE interval;
     VALUE out;
     VALUE metadata;
+    int ignore_gc;
 
     VALUE *raw_samples;
     size_t raw_samples_len;
@@ -73,8 +74,8 @@ static struct {
 
 static VALUE sym_object, sym_wall, sym_cpu, sym_custom, sym_name, sym_file, sym_line;
 static VALUE sym_samples, sym_total_samples, sym_missed_samples, sym_edges, sym_lines;
-static VALUE sym_version, sym_mode, sym_interval, sym_raw, sym_metadata, sym_frames, sym_out, sym_aggregate, sym_raw_timestamp_deltas;
-static VALUE sym_state, sym_marking, sym_sweeping;
+static VALUE sym_version, sym_mode, sym_interval, sym_raw, sym_metadata, sym_frames, sym_ignore_gc, sym_out;
+static VALUE sym_aggregate, sym_raw_timestamp_deltas, sym_state, sym_marking, sym_sweeping;
 static VALUE sym_gc_samples, objtracer;
 static VALUE gc_hook;
 static VALUE rb_mStackProf;
@@ -88,6 +89,7 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
     struct sigaction sa;
     struct itimerval timer;
     VALUE opts = Qnil, mode = Qnil, interval = Qnil, metadata = rb_hash_new(), out = Qfalse;
+    int ignore_gc = 0;
     int raw = 0, aggregate = 1;
 
     if (_stackprof.running)
@@ -99,6 +101,9 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
 	mode = rb_hash_aref(opts, sym_mode);
 	interval = rb_hash_aref(opts, sym_interval);
 	out = rb_hash_aref(opts, sym_out);
+	if (RTEST(rb_hash_aref(opts, sym_ignore_gc))) {
+	    ignore_gc = 1;
+	}
 
 	VALUE metadata_val = rb_hash_aref(opts, sym_metadata);
 	if (RTEST(metadata_val)) {
@@ -151,6 +156,7 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
     _stackprof.aggregate = aggregate;
     _stackprof.mode = mode;
     _stackprof.interval = interval;
+    _stackprof.ignore_gc = ignore_gc;
     _stackprof.metadata = metadata;
     _stackprof.out = out;
 
@@ -610,7 +616,7 @@ static void
 stackprof_signal_handler(int sig, siginfo_t *sinfo, void *ucontext)
 {
     _stackprof.overall_signals++;
-    if (rb_during_gc()) {
+    if (!_stackprof.ignore_gc && rb_during_gc()) {
 	VALUE mode = rb_gc_latest_gc_info(sym_state);
 	if (mode == sym_marking) {
 	    _stackprof.unrecorded_gc_marking_samples++;
@@ -722,6 +728,7 @@ Init_stackprof(void)
     S(raw_timestamp_deltas);
     S(out);
     S(metadata);
+    S(ignore_gc);
     S(frames);
     S(aggregate);
     S(state);


### PR DESCRIPTION
For longer traces, garbage collection frames can make flamegraphs harder to read (long method invocations are broken up into segments when garbage collection interrupts it) when not considering garbage collection times. This option flag can be passed to not record these frames.

Without `ignore_gc`:
<img width="545" alt="Screen Shot 2020-02-10 at 9 55 27 PM" src="https://user-images.githubusercontent.com/131426/74210199-5677ae00-4c50-11ea-9722-fab1eb08fa98.png">
With `ignore_gc`:
<img width="573" alt="Screen Shot 2020-02-10 at 9 55 33 PM" src="https://user-images.githubusercontent.com/131426/74210202-58da0800-4c50-11ea-9b98-57e75f03e1f3.png">
