### PR TITLE
Handle source code not being available

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -654,7 +654,8 @@ module StackProf
           end
         end
       end
+    rescue SystemCallError
+      f.puts "        SOURCE UNAVAILABLE"
     end
-
   end
 end


### PR DESCRIPTION
Fairly often I analyze profiling data coming from other machines (e.g. production or CI, etc).

Because of this, very often the recorded source path doesn't exist on my machine which cause the stackprof report to crash:

```
$ stackprof ~/Downloads/stackprof-shopify-boot-production-cpu\ \(6\).dump --method=CSV::Parser#parse_quotable_loose --walk
CSV::Parser#parse_quotable_loose (/usr/lib/ruby-shopify/ruby-shopify-2.7.1/lib/ruby/2.7.0/csv/parser.rb:821)
  samples:   314 self (0.5%)  /   1402 total (2.3%)
  callers:
    1402  (  100.0%)  CSV::Parser#parse
    1096  (   78.2%)  CSV::Parser::InputsScanner#each_line
      51  (    3.6%)  CSV::Parser::Scanner#each_line
  callees (1088 total):
    1348  (  123.9%)  CSV::Parser::InputsScanner#each_line
     703  (   64.6%)  CSV::Parser#emit_row
      65  (    6.0%)  CSV::Parser::InputsScanner#keep_drop
      60  (    5.5%)  CSV::Parser::InputsScanner#keep_start
      54  (    5.0%)  CSV::Parser::Scanner#each_line
       3  (    0.3%)  CSV::Parser::Scanner#keep_drop
       2  (    0.2%)  CSV::Parser::Scanner#keep_start
  code:
Traceback (most recent call last):
	8: from /Users/byroot/.gem/ruby/2.7.1/bin/stackprof:23:in `<main>'
	7: from /Users/byroot/.gem/ruby/2.7.1/bin/stackprof:23:in `load'
	6: from /Users/byroot/.gem/ruby/2.7.1/gems/stackprof-0.2.15/bin/stackprof:88:in `<top (required)>'
	5: from /Users/byroot/.gem/ruby/2.7.1/gems/stackprof-0.2.15/lib/stackprof/report.rb:529:in `walk_method'
	4: from /Users/byroot/.gem/ruby/2.7.1/gems/stackprof-0.2.15/lib/stackprof/report.rb:490:in `print_method'
	3: from /Users/byroot/.gem/ruby/2.7.1/gems/stackprof-0.2.15/lib/stackprof/report.rb:490:in `each'
	2: from /Users/byroot/.gem/ruby/2.7.1/gems/stackprof-0.2.15/lib/stackprof/report.rb:517:in `block in print_method'
	1: from /Users/byroot/.gem/ruby/2.7.1/gems/stackprof-0.2.15/lib/stackprof/report.rb:637:in `source_display'
/Users/byroot/.gem/ruby/2.7.1/gems/stackprof-0.2.15/lib/stackprof/report.rb:637:in `readlines': No such file or directory @ rb_sysopen - /usr/lib/ruby-shopify/ruby-shopify-2.7.1/lib/ruby/2.7.0/csv/parser.rb (Errno::ENOENT)
```

This PR properly handle this edge case:

```
$ bundle exec bin/stackprof ~/Downloads/stackprof-shopify-boot-production-cpu\ \(6\).dump --method=CSV::Parser#parse_quotable_loose
CSV::Parser#parse_quotable_loose (/usr/lib/ruby-shopify/ruby-shopify-2.7.1/lib/ruby/2.7.0/csv/parser.rb:821)
  samples:   314 self (0.5%)  /   1402 total (2.3%)
  callers:
    1402  (  100.0%)  CSV::Parser#parse
    1096  (   78.2%)  CSV::Parser::InputsScanner#each_line
      51  (    3.6%)  CSV::Parser::Scanner#each_line
  callees (1088 total):
    1348  (  123.9%)  CSV::Parser::InputsScanner#each_line
     703  (   64.6%)  CSV::Parser#emit_row
      65  (    6.0%)  CSV::Parser::InputsScanner#keep_drop
      60  (    5.5%)  CSV::Parser::InputsScanner#keep_start
      54  (    5.0%)  CSV::Parser::Scanner#each_line
       3  (    0.3%)  CSV::Parser::Scanner#keep_drop
       2  (    0.2%)  CSV::Parser::Scanner#keep_start
  code:
        SOURCE UNAVAILABLE
```

@tenderlove @rafaelfranca