### PR TITLE
Faster flamegraph generation

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -40,7 +40,7 @@ module StackProf
     end
 
     def max_samples
-      @data[:max_samples] ||= frames.max_by{ |addr, frame| frame[:samples] }.last[:samples]
+      @data[:max_samples] ||= @data[:frames].values.max_by{ |frame| frame[:samples] }[:samples]
     end
 
     def files
@@ -192,7 +192,7 @@ module StackProf
     end
 
     def flamegraph_row(f, x, y, weight, addr)
-      frame = frames[addr]
+      frame = @data[:frames][addr]
       f.print ',' if @rows_started
       @rows_started = true
       f.puts %{{"x":#{x},"y":#{y},"width":#{weight},"frame_id":#{addr},"frame":#{frame[:name].dump},"file":#{frame[:file].dump}}}
@@ -213,7 +213,7 @@ module StackProf
             weight += stack.last
           end
         else
-          frame = frames[val]
+          frame = @data[:frames][addr]
           child_name = "#{ frame[:name] } : #{ frame[:file] }"
           child_data = convert_to_d3_flame_graph_format(child_name, child_stacks, depth + 1)
           weight += child_data["value"]

--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pp'
 require 'digest/md5'
 


### PR DESCRIPTION
This PR makes flamegraph generation significantly faster. The main change is to create cursor objects pointing into the raw buffer instead of slicing arrays out of the raw buffer.

**Before**
```
jhawthorn@guardian:~/src/stackprof (master ) [ruby 2.8.0]
$ time ruby -Ilib bin/stackprof --flamegraph stackprof-test-boot.dump > /dev/null
31.52s user 0.24s system 99% cpu 31.891 total
```

**After**
```
jhawthorn@guardian:~/src/stackprof (faster_reporting ) [ruby 2.8.0]
$ time ruby -Ilib bin/stackprof --flamegraph stackprof-test-boot.dump > /dev/null
6.69s user 0.16s system 99% cpu 6.875 total
```


I found this using stackprof on its own reporting 😆 ♻️

``` ruby
# frozen_string_literal: true

require "stackprof"

report = StackProf::Report.new(Marshal.load(IO.binread(ARGV[0])))

output = File.open("/dev/null", "wb")
StackProf.run(mode: :wall, out: 'stackprof-stackprof.dump') do
  report.print_timeline_flamegraph(output)
end
```