### PR TITLE
fix variable name.

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -213,7 +213,7 @@ module StackProf
             weight += stack.last
           end
         else
-          frame = @data[:frames][addr]
+          frame = @data[:frames][val]
           child_name = "#{ frame[:name] } : #{ frame[:file] }"
           child_data = convert_to_d3_flame_graph_format(child_name, child_stacks, depth + 1)
           weight += child_data["value"]


### PR DESCRIPTION
fd2cffa90216b643a785830f0592eba6aafa582b modified to use `addr`,
but `val` is correct variable to use here.