### PR TITLE
Make more accessible the profiler from TruffleRuby on GraalVM

### DIFF
--- a/ext/stackprof/extconf.rb
+++ b/ext/stackprof/extconf.rb
@@ -1,5 +1,7 @@
 require 'mkmf'
-if have_func('rb_postponed_job_register_one') &&
+if RUBY_ENGINE == 'truffleruby'
+  fail "try truffleruby's profiler \nruby --experimental-options --cpusampler --cpusampler.Mode=roots --cpusampler.SampleInternal FILE.rb"
+elsif have_func('rb_postponed_job_register_one') &&
    have_func('rb_profile_frames') &&
    have_func('rb_tracepoint_new') &&
    have_const('RUBY_INTERNAL_EVENT_NEWOBJ')

--- a/lib/stackprof.rb
+++ b/lib/stackprof.rb
@@ -1,7 +1,7 @@
 require "stackprof/stackprof"
 
 module StackProf
-  VERSION = '0.2.15'
+  VERSION = '0.2.16'
 end
 
 StackProf.autoload :Report, "stackprof/report.rb"

--- a/stackprof.gemspec
+++ b/stackprof.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'stackprof'
-  s.version = '0.2.15'
+  s.version = '0.2.16'
   s.homepage = 'http://github.com/tmm1/stackprof'
 
   s.authors = 'Aman Gupta'


### PR DESCRIPTION
Related to https://github.com/oracle/truffleruby/issues/2044

Hi there,
During experiments with TruffleRuby and, of course, with Stackprof gem, I think that it would be beneficial if we can show information about the profiler from TruffleRuby/GraalVM. It can help for a newbie and somebody how to discover Ruby/GraalVM environments.
I know that it is no big deal but nice to have a feature.
Please let me know what you think about it.