### PR TITLE
Fix FrozenError on `stackprof --graphviz`

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -445,7 +445,7 @@ module StackProf
         call, total = info.values_at(:samples, :total_samples)
         break if total < node_minimum || (limit && index >= limit)
 
-        sample = ''
+        sample = ''.dup
         sample << "#{call} (%2.1f%%)\\rof " % (call*100.0/overall_samples) if call < total
         sample << "#{total} (%2.1f%%)\\r" % (total*100.0/overall_samples)
         fontsize = (1.0 * call / max_samples) * 28 + 10


### PR DESCRIPTION
Since https://github.com/tmm1/stackprof/pull/136, `stackprof --graphviz` command raises a FrozenError.

```bash
$ stackprof stackprof-out --graphviz
digraph profile {
Legend [shape=box,fontsize=24,shape=plaintext,label="
Total samples: 598\lShowing top 120 nodes\lDropped nodes with < 3 samples\l"];
/path/to/stackprof-0.2.16/lib/stackprof/report.rb:449:in `block in print_graphviz': can't modify frozen String: "" (FrozenError)
	from /path/to/stackprof-0.2.16/lib/stackprof/report.rb:444:in `each'
	from /path/to/stackprof-0.2.16/lib/stackprof/report.rb:444:in `each_with_index'
	from /path/to/stackprof-0.2.16/lib/stackprof/report.rb:444:in `print_graphviz'
	from /path/to/stackprof-0.2.16/bin/stackprof:78:in `<top (required)>'
	from /path/to/bin/stackprof:23:in `load'
	from /path/to/bin/stackprof:23:in `<main>'
```

This pull request fixes this problem.



In this patch, I use `String#dup` instead of `String#+@` to melt the string. `String#+@` is faster, but it is not available on Ruby 2.2 and stackprof supports Ruby 2.2. 
https://github.com/tmm1/stackprof/blob/1a75be9d44e410e45b98db855819ee984061b470/stackprof.gemspec#L27