### PR TITLE
Collect stack frames immediately in Ruby 3.0

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -596,25 +596,17 @@ stackprof_record_gc_samples()
 static void
 stackprof_gc_job_handler(void *data)
 {
-    static int in_signal_handler = 0;
-    if (in_signal_handler) return;
     if (!_stackprof.running) return;
 
-    in_signal_handler++;
     stackprof_record_gc_samples();
-    in_signal_handler--;
 }
 
 static void
 stackprof_job_handler(void *data)
 {
-    static int in_signal_handler = 0;
-    if (in_signal_handler) return;
     if (!_stackprof.running) return;
 
-    in_signal_handler++;
     stackprof_record_sample();
-    in_signal_handler--;
 }
 
 static void


### PR DESCRIPTION
As of https://github.com/ruby/ruby/commit/0e276dc458f94d9d79a0f7c7669bde84abe80f21, which shipped in Ruby 3.0, it seems to be safe to collect stack frames inside the signal handler. This should allow more accurate results than waiting for the postponed job to run since that can only measure when interrupts are checked.

This new behaviour is wrapped inside a preprocessor check for Ruby 3+

Additionally, this moves the "in signal handler" checks up a level, and uses pthread_mutex_trylock, which should be more reliable and I _believe_ will fix the issue described in #123 and #124

@tenderlove and I had some discussion about whether this could have issues due to the writes in https://github.com/ruby/ruby/commit/0e276dc458f94d9d79a0f7c7669bde84abe80f21 being reordered.

One concern is whether there could be issues with hardware memory reordering (particularly on arm). I _believe_ this is safe only because we are only considering the stack from our current thread. These writes will appear consistent in our interrupt handler because of this.

Another concern is that the compiler could reorder the writes in https://github.com/ruby/ruby/commit/0e276dc458f94d9d79a0f7c7669bde84abe80f21. It doesn't seem to be, but that could absolutely happen. I think we should investigate making a change to Ruby to ensure the writes in `vm_push_frame`/`vm_pop_frame` aren't reordered.