### PR TITLE
Improve performance of `--d3-flamegraph` option

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -234,9 +234,13 @@ module StackProf
       stacks = []
       max_x = 0
       max_y = 0
-      while len = raw.shift
+      idx = 0
+
+      while len = raw[idx]
+        idx += 1
         max_y = len if len > max_y
-        stack = raw.slice!(0, len+1)
+        stack = raw.slice(idx, len+1)
+        idx += len+1
         stacks << stack
         max_x += stack.last
       end

--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -95,51 +95,10 @@ module StackProf
       print_flamegraph(f, skip_common, true)
     end
 
-    StackCursor = Struct.new(:raw, :idx, :length) do
-      def weight
-        @weight ||= raw[1 + idx + length]
-      end
-
-      def [](i)
-        if i >= length
-          nil
-        else
-          raw[1 + idx + i]
-        end
-      end
-
-      def <=>(other)
-        i = 0
-        while i < length && i < other.length
-          if self[i] != other[i]
-            return self[i] <=> other[i]
-          end
-          i += 1
-        end
-
-        return length <=> other.length
-      end
-    end
-
     def print_flamegraph(f, skip_common, alphabetical=false)
       raise "profile does not include raw samples (add `raw: true` to collecting StackProf.run)" unless raw = data[:raw]
 
-      stacks = []
-      max_x = 0
-      max_y = 0
-
-      idx = 0
-      loop do
-        len = raw[idx]
-        break unless len
-        max_y = len if len > max_y
-
-        stack = StackCursor.new(raw, idx, len)
-        stacks << stack
-        max_x += stack.weight
-
-        idx += len + 2
-      end
+      stacks, max_x, max_y = flamegraph_stacks(raw)
 
       stacks.sort! if alphabetical
 
@@ -150,7 +109,7 @@ module StackProf
         x = 0
 
         stacks.each do |stack|
-          weight = stack.weight
+          weight = stack.last
           cell = stack[y] unless y == stack.length-1
 
           if cell.nil?
@@ -189,6 +148,24 @@ module StackProf
         end
       end
       f.puts '])'
+    end
+
+    def flamegraph_stacks(raw)
+      stacks = []
+      max_x = 0
+      max_y = 0
+      idx = 0
+
+      while len = raw[idx]
+        idx += 1
+        max_y = len if len > max_y
+        stack = raw.slice(idx, len+1)
+        idx += len+1
+        stacks << stack
+        max_x += stack.last
+      end
+
+      return stacks, max_x, max_y
     end
 
     def flamegraph_row(f, x, y, weight, addr)
@@ -231,19 +208,7 @@ module StackProf
     def print_d3_flamegraph(f=STDOUT, skip_common=true)
       raise "profile does not include raw samples (add `raw: true` to collecting StackProf.run)" unless raw = data[:raw]
 
-      stacks = []
-      max_x = 0
-      max_y = 0
-      idx = 0
-
-      while len = raw[idx]
-        idx += 1
-        max_y = len if len > max_y
-        stack = raw.slice(idx, len+1)
-        idx += len+1
-        stacks << stack
-        max_x += stack.last
-      end
+      stacks, * = flamegraph_stacks(raw)
 
       # d3-flame-grpah supports only alphabetical flamegraph
       stacks.sort!


### PR DESCRIPTION
This change improves performance of `--d3-flamegraph` option.

Problem
====

`--d3-flamegraph` option is super slow if the stackprof's output file is
large.
With a 28MB file, it takes 198 sec.

```bash
$ du -h stackprof-out
28M	stackprof-out

$ stackprof --d3-flamegraph stackprof-out > /dev/null # it takes 192.12s
```

Profiling
===

I profiled it with stackprof. Slicing array is the bottleneck.

```
$ stackprof stackprof-out | head
==================================
  Mode: wall(1000)
  Samples: 80265 (61.03% miss rate)
  GC: 381 (0.47%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     79877  (99.5%)       78969  (98.4%)     StackProf::Report#print_d3_flamegraph
       902   (1.1%)         902   (1.1%)     StackProf::Report#convert_to_d3_flame_graph_format
       338   (0.4%)         338   (0.4%)     (marking)
        42   (0.1%)          42   (0.1%)     (sweeping)

$ stackprof stackprof-out -m print_d3_flamegraph
StackProf::Report#print_d3_flamegraph (/home/pocke/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/stackprof-0.2.16/lib/stackprof/report.rb:231)
  samples:  78969 self (98.4%)  /   79877 total (99.5%)
  callers:
    79877  (  100.0%)  <top (required)>
  callees (908 total):
     902  (   99.3%)  StackProf::Report#convert_to_d3_flame_graph_format
       5  (    0.6%)  Kernel#require
       1  (    0.1%)  #<Module:0x0000564f74b49280>.generate
  code:
                                  |   231  |     def print_d3_flamegraph(f=STDOUT, skip_common=true)
                                  |   232  |       raise "profile does not include raw samples (add `raw: true` to collecting StackProf.run)" unless raw = data[:raw]
                                  |   233  |
                                  |   234  |       stacks = []
                                  |   235  |       max_x = 0
                                  |   236  |       max_y = 0
 27684   (34.5%) /  27684  (34.5%)  |   237  |       while len = raw.shift
    4    (0.0%) /     4   (0.0%)  |   238  |         max_y = len if len > max_y
 50020   (62.3%) /  50020  (62.3%)  |   239  |         stack = raw.slice!(0, len+1)
                                  |   240  |         stacks << stack
   64    (0.1%) /    64   (0.1%)  |   241  |         max_x += stack.last
                                  |   242  |       end
                                  |   243  |
                                  |   244  |       # d3-flame-grpah supports only alphabetical flamegraph
 1195    (1.5%) /  1195   (1.5%)  |   245  |       stacks.sort!
                                  |   246  |
    5    (0.0%)                   |   247  |       require "json"
  903    (1.1%)                   |   248  |       json = JSON.generate(convert_to_d3_flame_graph_format("<root>", stacks, 0), max_nesting: false)
                                  |   249  |
                                  |   250  |       # This html code is almost copied from d3-flame-graph sample code.
                                  |   251  |       # (Apache License 2.0)
                                  |   252  |       # https://github.com/spiermar/d3-flame-graph/blob/gh-pages/index.html
                                  |   253  |
    2    (0.0%) /     2   (0.0%)  |   254  |       f.print <<-END
                                  |   255  | <!DOCTYPE html>
```

Solution
===

Do not mutate the array, but use an index for slicing instead.

With this change, `stackprof --d3-flamegraph` command with the same
stackprof's output takes only 2.33 sec, 82x faster🚀




# Reproduce


I benchmarked it with a stackprof's output of a real rails app, but you can reproduce this problem with a simple code, like following:

```ruby
def fibo(n)
  if n < 2
    1
  else
    fibo(n-1) + fibo(n-2)
  end
end

require 'stackprof'
StackProf.run(mode: :wall, out: 'stackprof-out', raw: true) do
  50.times do
    fibo 36
  end
end
```

With this code, `stackprof --d3-flamegraph` took 35 sec without this patch, but it is improved to 1.01 sec with this patch.