### PR TITLE
Fix infinite realloc loop when rb_profile_frames returns 0

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -472,7 +472,7 @@ stackprof_record_sample_for_stack(int num, int64_t timestamp_delta)
 
     _stackprof.overall_samples++;
 
-    if (_stackprof.raw) {
+    if (_stackprof.raw && num > 0) {
 	int found = 0;
 
 	/* If there's no sample buffer allocated, then allocate one.  The buffer


### PR DESCRIPTION
Sometimes rb_profile_frames returns 0. If this happens before raw_samples is allocated for the first time, stackprof_record_sample_for_stack can enter an infinite loop as it tries to realloc raw_samples by doubling raw_samples_capa, which is 0 when num is 0.