### PR TITLE
Fix timestamp math for platforms without _POSIX_MONOTONIC_CLOCK

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -69,7 +69,7 @@ static const char *fake_frame_cstrs[] = {
   static int64_t delta_usec(timestamp_t *start, timestamp_t *end) {
       struct timeval diff;
       timersub(end, start, &diff);
-      return (1000 * diff.tv_sec) + diff.tv_usec;
+      return (MICROSECONDS_IN_SECOND * diff.tv_sec) + diff.tv_usec;
   }
 #endif
 


### PR DESCRIPTION
This is pretty much a rebase of https://github.com/tmm1/stackprof/pull/122, so credits to @benbuckman.

Following https://github.com/tmm1/stackprof/pull/161, most platform use the `clock_gettime` version of the code, so are not affected, but still worth fixing I guess.

@tenderlove 