### PR TITLE
Make test_cputime more reliable

### DIFF
--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -78,9 +78,14 @@ class StackProfTest < MiniTest::Test
     end
 
     assert_operator profile[:samples], :>=, 1
-    offset = RUBY_VERSION >= '3' ? 1 : 0
-    frame = profile[:frames].values[offset]
-    assert_includes frame[:name], "StackProfTest#math"
+    if RUBY_VERSION >= '3'
+      assert profile[:frames].values.take(2).map { |f|
+        f[:name].include? "StackProfTest#math"
+      }.any?
+    else
+      frame = profile[:frames].values.first
+      assert_includes frame[:name], "StackProfTest#math"
+    end
   end
 
   def test_walltime


### PR DESCRIPTION
It seems the order of the frames hash values in test_cputime is somewhat
nondeterministic, at least with Ruby > 3. Most of the time the
"StackProfTest#math" frame will be at index 1, but sometimes it shows up
at index 0, like it does with Ruby < 3. This commit updates the test to
accept it in either position.