### PR TITLE
Fix timestamp math for platforms with _POSIX_MONOTONIC_CLOCK

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -49,9 +49,9 @@ static const char *fake_frame_cstrs[] = {
   }
 
   static int64_t delta_usec(timestamp_t *start, timestamp_t *end) {
-      int64_t result = 1000 * (end->tv_sec - start->tv_sec);
+      int64_t result = MICROSECONDS_IN_SECOND * (end->tv_sec - start->tv_sec);
       if (end->tv_nsec < start->tv_nsec) {
-	  result -= 1000;
+	  result -= MICROSECONDS_IN_SECOND;
 	  result += (NANOSECONDS_IN_SECOND + end->tv_nsec - start->tv_nsec) / 1000;
       } else {
 	  result += (end->tv_nsec - start->tv_nsec) / 1000;


### PR DESCRIPTION
Hello, hello! 🎉

First the disclaimer (I guess it may be relevant): I work at @DataDog on profiling for the [ddtrace](https://github.com/DataDog/dd-trace-rb) gem, although we don't use `rb_profile_frames` (but it is quite interesting).

I noticed that the fix for #122 in #163 actually missed the new `_POSIX_MONOTONIC_CLOCK` branch, where the math was still incorrect (used 1000 instead of 1000000 when attempting to convert seconds to microseconds).

cc @djudd @casperisfine