### PR TITLE
Show line number in d3-flamegraph

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -191,7 +191,7 @@ module StackProf
           end
         else
           frame = @data[:frames][val]
-          child_name = "#{ frame[:name] } : #{ frame[:file] }"
+          child_name = "#{ frame[:name] } : #{ frame[:file] } : #{ frame[:line] }"
           child_data = convert_to_d3_flame_graph_format(child_name, child_stacks, depth + 1)
           weight += child_data["value"]
           children << child_data


### PR DESCRIPTION
Blocks have no name, so it's hard to identify blocks without line numbers if there are more than 2 blocks.
However, d3-flamegraph does not show line numbers of blocks:
(The frame at the bottom of the screenshot)

![Screenshot from 2021-09-20 17-44-46](https://user-images.githubusercontent.com/3054386/133976699-6d41925a-5d86-4f25-961d-3dfcefc2879e.png)

In order to show line numbers of blocks, I added `frame[:line]` to `child_name`.
After this modification, we can see line numbers of blocks.

![Screenshot from 2021-09-20 17-45-56](https://user-images.githubusercontent.com/3054386/133976702-35cf0d38-3b87-4fcd-b388-92b9a41f7808.png)

