### PR TITLE
Record sample timestamps in :raw mode (proposal)

### DIFF
--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -152,7 +152,7 @@ class StackProfTest < MiniTest::Test
 
     assert_equal 10, profile[:raw_timestamp_deltas].size
     total_duration = after_monotonic - before_monotonic
-    assert_operator profile[:raw_timestamp_deltas].sum, :<, total_duration
+    assert_operator profile[:raw_timestamp_deltas].inject(&:+), :<, total_duration
   end
 
   def test_metadata

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -126,11 +126,15 @@ class StackProfTest < MiniTest::Test
   end
 
   def test_raw
+    before_monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
+
     profile = StackProf.run(mode: :custom, raw: true) do
       10.times do
         StackProf.sample
       end
     end
+
+    after_monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
 
     raw = profile[:raw]
     assert_equal 10, raw[-1]
@@ -138,7 +142,17 @@ class StackProfTest < MiniTest::Test
 
     offset = RUBY_VERSION >= '3' ? -3 : -2
     assert_includes profile[:frames][raw[offset]][:name], 'StackProfTest#test_raw'
+
+    assert_equal 10, profile[:raw_sample_timestamps].size
+    profile[:raw_sample_timestamps].each_cons(2) do |t1, t2|
+      assert_operator t1, :>, before_monotonic
+      assert_operator t2, :>=, t1
+      assert_operator t2, :<, after_monotonic
+    end
+
     assert_equal 10, profile[:raw_timestamp_deltas].size
+    total_duration = after_monotonic - before_monotonic
+    assert_operator profile[:raw_timestamp_deltas].sum, :<, total_duration
   end
 
   def test_metadata


### PR DESCRIPTION
This PR adds a `:raw_sample_timestamps` key to results in `:raw` mode, which contains the (starting) timestamp of each sample in microseconds-since-some-arbitrary-time, which will be the monotonic clock zero on most operating systems or the epoch on systems that don't support it. This isn't quite redundant with the existing `:raw_timestamp_deltas` because the latter exclude time spent sampling in Stackprof - each subtracts the ending time of the previous sample from the starting time of this sample.

My use case is joining the Stackprof sample data against other tracing information which uses the same OS clock in post-processing. In particular, this is useful for working around the limitations of Stackprof in a multithreaded environment, where ownership of the GVL may return to an arbitrary thread while the main thread is blocked, and so you can no longer tell from the stack sample alone what the main thread was blocked on. However, if you have tracing around I/O calls plus these timestamps, you can reconstruct that information.

An alternate design would be to change the semantics of `:raw_timestamp_deltas` so that they no longer exclude Stackprof sample time, which would let you convert them to wall time with a cumulative sum. We could drop back to just capturing a timestamp once per sample. This might be how I'd have designed things from scratch but seems like a larger compatibility break.

Thoughts @tenderlove?