### PR TITLE
Remove unused variable

### DIFF
--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -224,7 +224,6 @@ class StackProfTest < MiniTest::Test
       end
     end
 
-    raw = profile[:raw]
     gc_frame = profile[:frames].values.find{ |f| f[:name] == "(garbage collection)" }
     marking_frame = profile[:frames].values.find{ |f| f[:name] == "(marking)" }
     sweeping_frame = profile[:frames].values.find{ |f| f[:name] == "(sweeping)" }


### PR DESCRIPTION
Remove unused variable causing the warning: 

```
/home/runner/work/stackprof/stackprof/test/test_stackprof.rb:227: warning: assigned but unused variable - raw
```