### PR TITLE
Use more accurate profiling on Ruby 3.1 and fix async-signal-safety

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -7,6 +7,7 @@
 **********************************************************************/
 
 #include <ruby/ruby.h>
+#include <ruby/version.h>
 #include <ruby/debug.h>
 #include <ruby/st.h>
 #include <ruby/io.h>


### PR DESCRIPTION
## Accuracy Regression

In Ruby 3.1, stackprof was building with the warning:

```
../../../../ext/stackprof/stackprof.c:31:5: warning: "RUBY_API_VERSION_MAJOR" is not defined, evaluates to 0 [-Wundef]
   31 | #if RUBY_API_VERSION_MAJOR < 3
      |     ^~~~~~~~~~~~~~~~~~~~~~
```

Because of this, stackprof wasn't using the much improved accuracy added in https://github.com/tmm1/stackprof/pull/150 for Ruby 3.0+. This is fixed by adding an include of `ruby/version.h`

## Async signal safety

Revisiting https://github.com/tmm1/stackprof/pull/150, I noticed that approach wasn't quite safe 😅.

Unfortunately though rb_profile_frames seems to be safe to call inside a signal handler, stackprof_record_sample_for_stack is not, since it calls malloc (itself or through st_*) which is not async-signal-safe. This could potentially result in deadlocks or memory corruption depending on the malloc implementation.

This commit attempts to restore the safety of the postponed job approach while keeping the accuracy of measuring immediately. Inside the signal handler we record the frames to a buffer, then enqueue a postponed job to do the actual recording.


I am interested in further improving this by adding a worker thread to do the processing of the buffer instead of doing it in the postponed job, however I'd like to apply this as a smaller fix first and attempt that in a future PR.