### PR TITLE
Fix timestamp delta calculations

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -615,7 +615,7 @@ stackprof_buffer_sample(void)
 	struct timestamp_t t;
 	capture_timestamp(&t);
 	start_timestamp = timestamp_usec(&t);
-	timestamp_delta = delta_usec(&t, &_stackprof.last_sample_at);
+	timestamp_delta = delta_usec(&_stackprof.last_sample_at, &t);
     }
 
     num = rb_profile_frames(0, sizeof(_stackprof.frames_buffer) / sizeof(VALUE), _stackprof.frames_buffer, _stackprof.lines_buffer);
@@ -638,7 +638,7 @@ stackprof_record_gc_samples(void)
 
 	// We don't know when the GC samples were actually marked, so let's
 	// assume that they were marked at a perfectly regular interval.
-	delta_to_first_unrecorded_gc_sample = delta_usec(&t, &_stackprof.last_sample_at) - (_stackprof.unrecorded_gc_samples - 1) * NUM2LONG(_stackprof.interval);
+	delta_to_first_unrecorded_gc_sample = delta_usec(&_stackprof.last_sample_at, &t) - (_stackprof.unrecorded_gc_samples - 1) * NUM2LONG(_stackprof.interval);
 	if (delta_to_first_unrecorded_gc_sample < 0) {
 	    delta_to_first_unrecorded_gc_sample = 0;
 	}

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -131,6 +131,7 @@ class StackProfTest < MiniTest::Test
     profile = StackProf.run(mode: :custom, raw: true) do
       10.times do
         StackProf.sample
+        sleep 0.0001
       end
     end
 
@@ -153,6 +154,10 @@ class StackProfTest < MiniTest::Test
     assert_equal 10, profile[:raw_timestamp_deltas].size
     total_duration = after_monotonic - before_monotonic
     assert_operator profile[:raw_timestamp_deltas].inject(&:+), :<, total_duration
+
+    profile[:raw_timestamp_deltas].each do |delta|
+      assert_operator delta, :>, 0
+    end
   end
 
   def test_metadata


### PR DESCRIPTION
delta_usec's first argument is supposed to be the start and second is supposed to be the end. Previously we were passing these in the wrong order and getting negative deltas.

`git bisect` says this was broken in 4f7ee11d5f78870732b7ee6c92053e3432833655, but I suspect it had been broken since before that and it just happened that two wrongs did make a right 😅.

I think the measurement from this still isn't ideal, we're comparing timestamps recorded in the signal handler against timestamps in a postponed job. It's likely more accurate to compare samples (which are recorded at regular intervals) rather than deltas.