### PR TITLE
Switch hash algorithm from MD5 to SHA256

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'pp'
-require 'digest/md5'
+require 'digest/sha2'
 require 'json'
 
 module StackProf
@@ -52,7 +52,7 @@ module StackProf
     def normalized_frames
       id2hash = {}
       @data[:frames].each do |frame, info|
-        id2hash[frame.to_s] = info[:hash] = Digest::MD5.hexdigest("#{info[:name]}#{info[:file]}#{info[:line]}")
+        id2hash[frame.to_s] = info[:hash] = Digest::SHA256.hexdigest("#{info[:name]}#{info[:file]}#{info[:line]}")
       end
       @data[:frames].inject(Hash.new) do |hash, (frame, info)|
         info = hash[id2hash[frame.to_s]] = info.dup


### PR DESCRIPTION
Even though this use of MD5 isn't for security purposes, MD5 may not
be allowed at all on FIPS-compliant systems. Switch to SHA256 to
comply with FIPS 140-2 standards.