### PR TITLE
Use postponed jobs if YJIT is enabled.

### DIFF
--- a/lib/stackprof.rb
+++ b/lib/stackprof.rb
@@ -1,5 +1,9 @@
 require "stackprof/stackprof"
 
+if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
+  StackProf.use_postponed_job!
+end
+
 module StackProf
   VERSION = '0.2.19'
 end

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -5,6 +5,10 @@ require 'tempfile'
 require 'pathname'
 
 class StackProfTest < MiniTest::Test
+  def setup
+    Object.new # warm some caches to avoid flakiness
+  end
+
   def test_info
     profile = StackProf.run{}
     assert_equal 1.2, profile[:version]


### PR DESCRIPTION
Fix: https://github.com/tmm1/stackprof/issues/179

YJIT doesn't support being interrupted by signal in random places, and probably will never support it.

Basically turn off https://github.com/tmm1/stackprof/pull/150, if YJIT is enabled.

cc @tenderlove @XrXr @jhawthorn 
