### PR TITLE
Add support to the option ignore_gc to middleware

### DIFF
--- a/lib/stackprof/middleware.rb
+++ b/lib/stackprof/middleware.rb
@@ -7,23 +7,25 @@ module StackProf
       @options   = options
       @num_reqs  = options[:save_every] || nil
 
-      Middleware.mode     = options[:mode] || :cpu
-      Middleware.interval = options[:interval] || 1000
-      Middleware.raw      = options[:raw] || false
-      Middleware.enabled  = options[:enabled]
-      options[:path]      = 'tmp/' if options[:path].to_s.empty?
-      Middleware.path     = options[:path]
-      Middleware.metadata = options[:metadata] || {}
+      Middleware.mode      = options[:mode] || :cpu
+      Middleware.interval  = options[:interval] || 1000
+      Middleware.raw       = options[:raw] || false
+      Middleware.enabled   = options[:enabled]
+      options[:path]       = 'tmp/' if options[:path].to_s.empty?
+      Middleware.path      = options[:path]
+      Middleware.ignore_gc = options[:ignore_gc]
+      Middleware.metadata  = options[:metadata] || {}
       at_exit{ Middleware.save } if options[:save_at_exit]
     end
 
     def call(env)
       enabled = Middleware.enabled?(env)
       StackProf.start(
-        mode:     Middleware.mode,
-        interval: Middleware.interval,
-        raw:      Middleware.raw,
-        metadata: Middleware.metadata,
+        mode:      Middleware.mode,
+        interval:  Middleware.interval,
+        raw:       Middleware.raw,
+        ignore_gc: Middleware.raw,
+        metadata:  Middleware.metadata,
       ) if enabled
       @app.call(env)
     ensure
@@ -37,7 +39,13 @@ module StackProf
     end
 
     class << self
-      attr_accessor :enabled, :mode, :interval, :raw, :path, :metadata
+      attr_accessor :enabled,
+        :mode,
+        :interval,
+        :raw,
+        :path,
+        :ignore_gc,
+        :metadata
 
       def enabled?(env)
         if enabled.respond_to?(:call)
@@ -66,7 +74,6 @@ module StackProf
           filename
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
I'm using the middleware and saw that the garbage collection frames was polluting the dump a lot. Then I simply added the ignore_gc option and it did not work.

This is a simple addition of an option that already exists but it's not available on the middleware.