### PR TITLE
Use postponed jobs on Ruby 3.2.0

### DIFF
--- a/lib/stackprof.rb
+++ b/lib/stackprof.rb
@@ -6,6 +6,11 @@ end
 
 if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
   StackProf.use_postponed_job!
+elsif RUBY_VERSION == "3.2.0"
+  # 3.2.0 crash is the signal is received at the wrong time.
+  # Fixed in https://github.com/ruby/ruby/pull/7116
+  # The fix is backported in 3.2.1: https://bugs.ruby-lang.org/issues/19336
+  StackProf.use_postponed_job!
 end
 
 module StackProf


### PR DESCRIPTION
Otherwise it can cause a VM crash.
Won't be a problem in 3.2.1.

cc @jhawthorn @tenderlove 