### PR TITLE
Fix printing CLI banner

### DIFF
--- a/bin/stackprof
+++ b/bin/stackprof
@@ -2,13 +2,15 @@
 require 'optparse'
 require 'stackprof'
 
+banner = <<-END
+Usage: stackprof run [--mode=MODE|--out=FILE|--interval=INTERVAL|--format=FORMAT] -- COMMAND
+Usage: stackprof [file.dump]+ [--text|--method=NAME|--callgrind|--graphviz]
+END
+
 if ARGV.first == "run"
   ARGV.shift
   env = {}
-  parser = OptionParser.new(ARGV) do |o|
-    o.banner = "Usage: stackprof run [--mode=MODE|--out=FILE|--interval=INTERVAL|--format=FORMAT] -- COMMAND"
-    o.banner = "Usage: stackprof [file.dump]+ [--text|--method=NAME|--callgrind|--graphviz]"
-
+  parser = OptionParser.new(banner) do |o|
     o.on('--mode [MODE]', String, 'Mode of sampling: cpu, wall, object, default to wall') do |mode|
       env["STACKPROF_MODE"] = mode
     end
@@ -37,10 +39,7 @@ if ARGV.first == "run"
 else
   options = {}
 
-  parser = OptionParser.new(ARGV) do |o|
-    o.banner = "Usage: stackprof run [--mode|--out|--interval] -- COMMAND"
-    o.banner = "Usage: stackprof [file.dump]+ [--text|--method=NAME|--callgrind|--graphviz]"
-
+  parser = OptionParser.new(banner) do |o|
     o.on('--text', 'Text summary per method (default)'){ options[:format] = :text }
     o.on('--json', 'JSON output (use with web viewers)'){ options[:format] = :json }
     o.on('--files', 'List of files'){ |f| options[:format] = :files }


### PR DESCRIPTION
CLI was added in - https://github.com/tmm1/stackprof/pull/187

But it incorrectly prints banner when calling with `--help`, because `banner` is defined as `attr_writer` and the second assignment just overwrites the first, instead of "appending".

`$ stackprof --help`

### Before
```
Usage: stackprof [file.dump]+ [--text|--method=NAME|--callgrind|--graphviz]
        --text                       Text summary per method (default)
        --json                       JSON output (use with web viewers)
        --files                      List of files
        --limit [num]                Limit --text, --files, or --graphviz output to N entries
        --sort-total                 Sort --text or --files output on total samples
....
```

### After
```
Usage: stackprof run [--mode=MODE|--out=FILE|--interval=INTERVAL|--format=FORMAT] -- COMMAND
Usage: stackprof [file.dump]+ [--text|--method=NAME|--callgrind|--graphviz]
        --text                       Text summary per method (default)
        --json                       JSON output (use with web viewers)
        --files                      List of files
        --limit [num]                Limit --text, --files, or --graphviz output to N entries
        --sort-total                 Sort --text or --files output on total samples
.....
```

cc @byroot 