### PR TITLE
Mark frames_buffer

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -811,6 +811,10 @@ stackprof_gc_mark(void *data)
 
     if (_stackprof.frames)
 	st_foreach(_stackprof.frames, frame_mark_i, 0);
+
+    for (int i = 0; i < _stackprof.buffer_count; i++) {
+        rb_gc_mark(_stackprof.frames_buffer[i]);
+    }
 }
 
 static void


### PR DESCRIPTION
Objects in frames_buffer may not have been placed the frames ST table and may not be held on by Ruby meaning it could get garbage collected.