### PR TITLE
feat: Allow reading per-sample tags from fiber-local variable storage

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -500,7 +500,6 @@ stackprof_results(int argc, VALUE *argv, VALUE self)
     _stackprof.current_ruby_thread_id = 0;
     _stackprof.overall_tags = 0;
     _stackprof.buffered_tagsets = 0;
-    _stackprof.buffer_count = 0;
     _stackprof.current_buffered_tags_count = 0;
 
     if (_stackprof.raw && _stackprof.raw_samples_len) {

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -481,6 +481,8 @@ stackprof_results(int argc, VALUE *argv, VALUE self)
             st_foreach(_stackprof.sample_tags[n].tags, sample_tags_i, (st_data_t)tags);
             rb_ary_push(sample_tags, tags);
             rb_ary_push(sample_tags, ULONG2NUM(_stackprof.sample_tags[n].repeats));
+            st_free_table(_stackprof.sample_tags[n].tags);
+            _stackprof.sample_tags[n].tags = NULL;
         }
         rb_hash_aset(results, sym_sample_tags, sample_tags);
     }
@@ -746,6 +748,8 @@ stackprof_record_tags_for_sample(void)
 
     if (_stackprof.last_tagset_matches) {
         last_tag_data->repeats++;
+        st_free_table(tag_data.tags);
+        tag_data.tags = NULL;
     } else {
         _stackprof.sample_tags[_stackprof.sample_tags_len++] = tag_data;
     }

--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -178,7 +178,7 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
     struct sigaction sa;
     struct itimerval timer;
     VALUE opts = Qnil, mode = Qnil, interval = Qnil, metadata = rb_hash_new(), out = Qfalse;
-    VALUE tag_source = Qnil, tags = Qnil;
+    VALUE tag_source = Qnil, tags_arg = Qnil, tags = Qnil;
     int ignore_gc = 0;
     int raw = 0, aggregate = 1;
     VALUE metadata_val;
@@ -222,9 +222,10 @@ stackprof_start(int argc, VALUE *argv, VALUE self)
         }
 
         if (RTEST(rb_hash_aref(opts, sym_tags))) {
-            tags = rb_hash_aref(opts, sym_tags);
-            if (!RB_TYPE_P(tags, T_ARRAY))
+            tags_arg = rb_hash_aref(opts, sym_tags);
+            if (!RB_TYPE_P(tags_arg, T_ARRAY))
                 rb_raise(rb_eArgError, "tags should be an array");
+            tags = rb_ary_dup(tags_arg);
             if (rb_ary_includes(tags, sym_thread_id)) {
                 rb_ary_delete(tags, sym_thread_id);
                 _stackprof.tag_thread_id = Qtrue;

--- a/lib/stackprof.rb
+++ b/lib/stackprof.rb
@@ -2,6 +2,7 @@ if RUBY_ENGINE == 'truffleruby'
   require "stackprof/truffleruby"
 else
   require "stackprof/stackprof"
+  require "stackprof/tags"
 end
 
 if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?

--- a/lib/stackprof/tags.rb
+++ b/lib/stackprof/tags.rb
@@ -7,6 +7,7 @@ module StackProf
         before = check(tag_source: tag_source)
         set(**tags, tag_source: tag_source)
         yield
+      ensure
         Thread.current[tag_source] = before
       end
 

--- a/lib/stackprof/tags.rb
+++ b/lib/stackprof/tags.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module StackProf
+  module Tag
+    class << self
+      def with(tag_source: DEFAULT_TAG_SOURCE, **tags)
+        before = check(tag_source: tag_source)
+        set(**tags, tag_source: tag_source)
+        yield
+        Thread.current[tag_source] = before
+      end
+
+      def set(tag_source: DEFAULT_TAG_SOURCE, **tags)
+        Thread.current[tag_source] ||= {}
+        Thread.current[tag_source].merge!(tags)
+      end
+
+      def unset(*tags, tag_source: default_tag_source)
+        return unless thread.current[tag_source].is_a?(hash)
+        new_tags = thread.current[tag_source].dup
+        tags.each { |tag| new_tags.delete(tag) }
+        thread.current[tag_source] = new_tags # aims to be atomic so tagset is consistent
+      end
+
+      def clear(tag_source: DEFAULT_TAG_SOURCE)
+        Thread.current[tag_source].clear if Thread.current[tag_source].is_a?(Hash)
+      end
+
+      def check(tag_source: DEFAULT_TAG_SOURCE)
+        (Thread.current[tag_source] || {}).dup
+      end
+    end
+  end
+end

--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -11,7 +11,7 @@ class StackProfTest < MiniTest::Test
 
   def test_info
     profile = StackProf.run{}
-    assert_equal 1.2, profile[:version]
+    assert_equal 1.3, profile[:version]
     assert_equal :wall, profile[:mode]
     assert_equal 1000, profile[:interval]
     assert_equal 0, profile[:samples]

--- a/test/test_stackprof_tags.rb
+++ b/test/test_stackprof_tags.rb
@@ -73,6 +73,17 @@ class StackProfTagsTest < MiniTest::Test
     assert_equal true, tag_order_matches(profile, [{}, { foo: 'bar' }, {}])
   end
 
+  def test_tag_with_helper_unsets_tags_after_exception
+    begin
+      StackProf::Tag.with(foo: :bar) do
+        assert_operator StackProf::Tag.check, :==, { foo: :bar }
+        raise
+      end
+    rescue
+    end
+    assert_operator StackProf::Tag.check, :==, { }
+  end
+
   def test_tag_sample_from_custom_tag_source
     custom_tag_source = :my_custom_tag_source
     StackProf::Tag.set(foo: :bar, tag_source: custom_tag_source)

--- a/test/test_stackprof_tags.rb
+++ b/test/test_stackprof_tags.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'stackprof'
+require 'minitest/autorun'
+
+class StackProfTagsTest < MiniTest::Test
+  def test_tag_fields_present_if_tags
+    profile = StackProf.run(tags: [:thread_id]) do
+      assert_operator StackProf::Tag.check, :==, {}
+      math
+    end
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_equal true, profile.key?(:tag_strings)
+  end
+
+  def test_tag_fields_not_present_if_no_tags
+    profile = StackProf.run do
+      assert_operator StackProf::Tag.check, :==, {}
+      math
+    end
+
+    assert_equal false, profile.key?(:sample_tags)
+    assert_equal false, profile.key?(:tag_strings)
+  end
+
+  def test_one_tagset_per_profile
+    profile = StackProf.run(tags: [:thread_id]) do
+      assert_operator StackProf::Tag.check, :==, {}
+      math
+    end
+
+    assert_equal profile[:samples], profile[:num_tags]
+    assert_equal true, profile.key?(:sample_tags)
+    assert_equal profile[:num_tags], profile[:sample_tags].select{|e| e.is_a?(Integer)}.inject(0, :+)
+  end
+
+private
+
+  def math(n = 1)
+    base = 250_000
+    (n * base).times do
+      2**10
+    end
+  end
+end unless RUBY_ENGINE == 'truffleruby'

--- a/test/test_stackprof_tags.rb
+++ b/test/test_stackprof_tags.rb
@@ -5,6 +5,11 @@ require 'stackprof'
 require 'minitest/autorun'
 
 class StackProfTagsTest < MiniTest::Test
+  def teardown
+    StackProf::Tag.clear
+    StackProf::Tag::Persistence.disable
+  end
+
   def test_tag_fields_present_if_tags
     profile = StackProf.run(tags: [:thread_id]) do
       assert_operator StackProf::Tag.check, :==, {}
@@ -13,6 +18,7 @@ class StackProfTagsTest < MiniTest::Test
 
     assert_equal true, profile.key?(:sample_tags)
     assert_equal true, profile.key?(:tag_strings)
+    assert_equal true, profile.key?(:num_tags)
   end
 
   def test_tag_fields_not_present_if_no_tags
@@ -23,6 +29,7 @@ class StackProfTagsTest < MiniTest::Test
 
     assert_equal false, profile.key?(:sample_tags)
     assert_equal false, profile.key?(:tag_strings)
+    assert_equal false, profile.key?(:num_tags)
   end
 
   def test_one_tagset_per_profile
@@ -33,15 +40,389 @@ class StackProfTagsTest < MiniTest::Test
 
     assert_equal profile[:samples], profile[:num_tags]
     assert_equal true, profile.key?(:sample_tags)
-    assert_equal profile[:num_tags], profile[:sample_tags].select{|e| e.is_a?(Integer)}.inject(0, :+)
+    assert_equal profile[:num_tags], profile[:sample_tags].select { |e| e.is_a?(Integer) }.inject(0, :+)
   end
 
-private
+  def test_tag_thread_id
+    profile = StackProf.run(mode: :wall, tags: [:thread_id], raw: true) do # FIXME: try :wall to make tests faster
+      assert_operator StackProf::Tag.check, :==, {}
+      math(10)
+    end
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_operator profile[:sample_tags].size, :>, 0
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true, all_samples_have_tag(profile, :thread_id)
+    assert_equal true, StackProf::Tags.from(profile).all? { |t| Thread.current.to_s.include?(t[:thread_id]) }
+  end
+
+  def test_tag_with_helper
+    profile = StackProf.run(mode: :cpu, tags: [:foo], raw: true) do
+      math(10)
+      StackProf::Tag.with(foo: :bar) do
+        assert_operator StackProf::Tag.check, :==, { foo: :bar }
+        math(10)
+      end
+      math(10)
+    end
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_operator profile[:sample_tags].size, :>, 0
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true, tag_order_matches(profile, [{}, { foo: 'bar' }, {}])
+  end
+
+  def test_tag_sample_from_custom_tag_source
+    custom_tag_source = :my_custom_tag_source
+    StackProf::Tag.set(foo: :bar, tag_source: custom_tag_source)
+    profile = StackProf.run(mode: :cpu, tags: [:foo], tag_source: custom_tag_source, raw: true) do
+      assert_operator StackProf::Tag.check(tag_source: custom_tag_source), :==, { foo: :bar }
+      math(10)
+    end
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_operator profile[:sample_tags].size, :>, 0
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true, all_samples_have_tag(profile, :foo)
+    assert_equal true, StackProf::Tags.from(profile).all? { |t| t[:foo] == 'bar' }
+  end
+
+  def test_tag_sample_with_symbol_or_string
+    StackProf::Tag.set(foo: :bar, spam: 'a lot')
+
+    profile = StackProf.run(mode: :cpu, tags: %i[foo spam], raw: true) do
+      assert_operator StackProf::Tag.check, :==, { foo: :bar, spam: 'a lot' }
+      math(10)
+    end
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_operator profile[:sample_tags].size, :>, 0
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true, all_samples_have_tag(profile, :foo)
+    assert_equal true, StackProf::Tags.from(profile).all? { |t| t[:foo] == 'bar' }
+    assert_equal true, all_samples_have_tag(profile, :spam)
+    assert_equal true, StackProf::Tags.from(profile).all? { |t| t[:spam] == 'a lot' }
+  end
+
+  def test_tag_samples_with_tags_as_closure
+    profile = StackProf.run(mode: :cpu, tags: %i[foo spam], raw: true) do
+      math(10)
+      StackProf::Tag.with(foo: :bar) do
+        assert_operator StackProf::Tag.check, :==, { foo: :bar }
+        math(10)
+        StackProf::Tag.with(foo: :baz) do
+          assert_operator StackProf::Tag.check, :==, { foo: :baz }
+          math(10)
+          StackProf::Tag.with(spam: :eggs) do
+            assert_operator StackProf::Tag.check, :==, { foo: :baz, spam: :eggs }
+            math(10)
+          end
+          math(10)
+        end
+        math(10)
+      end
+      math(10)
+    end
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_operator profile[:sample_tags].size, :>, 0
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true,
+                 tag_order_matches(profile,
+                                   [{},
+                                    { foo: 'bar' },
+                                    { foo: 'baz' },
+                                    { foo: 'baz', spam: 'eggs' },
+                                    { foo: 'baz' },
+                                    { foo: 'bar' },
+                                    {}])
+  end
+
+  def test_tag_sample_in_thread
+    thread_id = ''
+    profile = StackProf.run(mode: :cpu, tags: %i[thread_id foo spam], raw: true) do
+      Thread.new do
+        thread_id = parse_thread_id(Thread.current)
+        assert_operator StackProf::Tag.check, :==, {}
+        math(10)
+        StackProf::Tag.set(foo: :bar)
+        assert_operator StackProf::Tag.check, :==, { foo: :bar }
+        math(10)
+        StackProf::Tag.set(foo: :bar, spam: 'eggs')
+        assert_operator StackProf::Tag.check, :==, { foo: :bar, spam: 'eggs' }
+        math(10)
+      end.join
+    end
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_operator profile[:sample_tags].size, :>, 0
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true, all_samples_have_tag(profile, :thread_id)
+    assert_equal true,
+                 tag_order_matches(profile,
+                                   [{ thread_id: thread_id },
+                                    { thread_id: thread_id, foo: 'bar' },
+                                    { thread_id: thread_id, foo: 'bar', spam: 'eggs' }])
+  end
+
+  def test_truncate_tags_exceeding_length
+    max_tags = StackProf::Tag::MAX_TAGS
+    max_key_len = StackProf::Tag::MAX_TAG_KEY_LEN
+    max_val_len = StackProf::Tag::MAX_TAG_VAL_LEN
+
+    too_long_key = ('a' * (max_key_len + 1)).to_sym
+    truncated_key = ('a' * max_key_len).to_sym
+    StackProf::Tag.set(too_long_key => :bar)
+    assert_operator StackProf::Tag.check, :==, { too_long_key => :bar }
+    profile = StackProf.run(mode: :cpu, tags: [too_long_key]) do
+      math(10)
+    end
+    StackProf::Tag.clear
+    assert_operator StackProf::Tag.check, :==, {}
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_operator profile[:sample_tags].size, :>, 0
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true, all_samples_have_tag(profile, truncated_key)
+    assert_equal true,
+                 tag_order_matches(profile,
+                                   [{ truncated_key => 'bar' }])
+
+    too_long_val = ('a' * (max_val_len + 1))
+    truncated_val = ('a' * max_val_len)
+    StackProf::Tag.set(foo: too_long_val)
+    assert_operator StackProf::Tag.check, :==, { foo: too_long_val }
+    profile = StackProf.run(mode: :cpu, tags: %i[foo]) do
+      math(10)
+    end
+    StackProf::Tag.clear
+    assert_operator StackProf::Tag.check, :==, {}
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_operator profile[:sample_tags].size, :>, 0
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true, all_samples_have_tag(profile, :foo)
+    assert_equal true,
+                 tag_order_matches(profile,
+                                   [{ foo: truncated_val }])
+
+    too_many_tags = (max_tags + 1).times.map { :tag }
+    error = assert_raises(ArgumentError) do
+      StackProf.run(mode: :cpu, tags: too_many_tags) {}
+    end
+    assert_equal 'exceeding maximum number of tags', error.message
+  end
+
+  def test_no_tags_set
+    assert_operator StackProf::Tag.check, :==, {}
+    profile = StackProf.run(mode: :wall, tags: %i[foo]) do
+      assert_operator StackProf::Tag.check, :==, {}
+      math
+    end
+    assert_operator StackProf::Tag.check, :==, {}
+    assert_equal true, profile.key?(:sample_tags)
+    assert_equal profile[:samples], profile[:num_tags]
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true, StackProf::Tags.from(profile).all? { |t| t.empty? }
+  end
+
+  def test_tag_sample_from_tag_source_with_multiple_threads
+    main_id = parse_thread_id(Thread.current)
+    sub_id = ''
+    StackProf::Tag.set(foo: :bar)
+
+    profile = StackProf.run(mode: :cpu, tags: %i[thread_id foo], raw: true) do
+      assert_operator StackProf::Tag.check, :==, { foo: :bar }
+      math(10)
+      Thread.new do
+        sub_id = parse_thread_id(Thread.current)
+        math(10)
+        StackProf::Tag.set(foo: :baz)
+        assert_operator StackProf::Tag.check, :==, { foo: :baz }
+        math(10)
+      end.join
+      assert_operator StackProf::Tag.check, :==, { foo: :bar }
+      math(10)
+      StackProf::Tag.clear
+      assert_operator StackProf::Tag.check, :==, {}
+      math(10)
+    end
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_operator profile[:sample_tags].size, :>, 0
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true, all_samples_have_tag(profile, :thread_id)
+    assert_equal true,
+                 tag_order_matches(profile,
+                                   [{ thread_id: main_id, foo: 'bar' },
+                                    { thread_id: sub_id },
+                                    { thread_id: sub_id, foo: 'baz' },
+                                    { thread_id: main_id, foo: 'bar' },
+                                    { thread_id: main_id }])
+  end
+
+  def test_tagged_funtions_do_not_skew
+    def fast_function
+      StackProf::Tag.with(function: :fast) do
+        math(2)
+      end
+    end
+
+    def slow_function
+      StackProf::Tag.with(function: :slow) do
+        math(8)
+      end
+    end
+
+    profile = StackProf.run(mode: :cpu, tags: %i[thread_id function], raw: true) do
+      5.times do
+        math(5)
+        fast_function
+        math(5)
+        slow_function
+      end
+      math(5)
+    end
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_operator profile[:sample_tags].size, :>, 0
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true, all_samples_have_tag(profile, :thread_id)
+
+    main_tid = parse_thread_id(Thread.current)
+    expected_order = [{ thread_id: main_tid },
+                      { thread_id: main_tid, function: 'fast' },
+                      { thread_id: main_tid },
+                      { thread_id: main_tid, function: 'slow' }] * 5
+    expected_order << { thread_id: main_tid }
+
+    assert_equal true, tag_order_matches(profile, expected_order)
+
+    samples = parse_profile(profile)
+
+    sample_tags = StackProf::Tags.from(profile)
+    i = 0
+    while i < profile[:samples]
+      tags = sample_tags[i]
+      i += 1
+      function = tags[:function]
+      next unless function
+
+      # Ensure that none of the samples are mis-tagged
+      if function == :fast
+        assert_equal true, samples[i].any? { |f| f.include?('fast_function') }
+        assert_equal true, samples[i].all? { |f| !f.include?('slow_function') }
+      elsif function == :slow
+        assert_equal true, samples[i].any? { |f| f.include?('slow_function') }
+        assert_equal true, samples[i].all? { |f| !f.include?('fast_function') }
+      end
+    end
+  end
+
+  private
 
   def math(n = 1)
     base = 250_000
     (n * base).times do
       2**10
     end
+  end
+
+  def parse_thread_id(thread)
+    thread.to_s.scan(/#<Thread:(\w*)/).flatten.first
+  end
+
+  def all_samples_have_tag(profile, tag)
+    tags = StackProf::Tags.from(profile)
+    rc = tags.all? { |t| t.key?(tag) }
+  ensure
+    unless rc
+      missing = tags.count { |t| !t.key?(tag) }
+      puts "#{missing}/#{tags.size} samples did not contain the tag #{tag}"
+      puts "GC samples: #{profile[:gc_samples]}"
+      puts "Tags were: #{StackProf::Tags.from(profile).inspect}\nraw: #{profile[:sample_tags].inspect}\nstrtab: #{profile[:tag_strings].inspect}"
+      if profile[:raw] && missing <= 5 # arbitrary limit to prevent spamming output
+        samplemap = parse_profile(profile)
+        tags.each_with_index do |t, i|
+          puts "Sample missing tag #{tag}:\n#{samplemap[i].inspect}" unless t.key?(tag)
+        end
+      end
+    end
+  end
+
+  def tag_order_matches(profile, *permitted_orders)
+    debugstr = ''
+    rc = false
+    sampleIdx = 0
+    next_acceptable = nil
+
+    return rc if permitted_orders.empty?
+
+    sampleTags = StackProf::Tags.from(profile)
+
+    permitted_orders.each_with_index do |order, orderIdx|
+      idx = 0
+      acceptable = nil
+      sampleTags.each do |tags|
+        sampleIdx += 1
+        acceptable = order[idx]
+        next unless tags != acceptable && idx < order.size
+
+        idx += 1
+        next_acceptable = order[idx]
+        debugstr += format("%02d/%02d: %s != %s, next %s (order %d)\n", idx, order.size, tags, acceptable,
+                           next_acceptable, orderIdx)
+        break if tags != next_acceptable
+
+        acceptable = next_acceptable
+      end
+      rc = idx == (order.size - 1)
+      return rc if rc
+    end
+    rc
+  ensure
+    unless rc
+      puts "Failed on sample #{sampleIdx - 1}/#{sampleTags.size} -> #{sampleTags[sampleIdx - 1]} != #{next_acceptable}"
+      puts "GC samples: #{profile[:gc_samples]}"
+      puts "Tags were: #{StackProf::Tags.from(profile).inspect}\nraw: #{profile[:sample_tags].inspect}\nstrtab: #{profile[:tag_strings]}\n#{debugstr}"
+    end
+  end
+
+  # Parses the stackprof hash into a map of samples id to callchains
+  def parse_profile(profile)
+    return unless profile.key?(:raw)
+
+    stacks = {}
+    raw = profile[:raw]
+    i = 0
+    stack_id = 0
+    samples = 0
+    puts "NO DATA for sample #{i}" if raw.size == 0
+    while i < raw.size
+      stack_height = raw[i]
+      stack_id += 1
+      i += 1
+      j = 0
+
+      stack = []
+      while j < stack_height
+        j += 1
+        id = raw[i]
+        i += 1
+        frame = profile[:frames][id][:name]
+        stack.push frame
+      end
+
+      num_samples = raw[i]
+      j = 0
+      while j < num_samples
+        j += 1
+        samples += 1
+        # printf("sample %02d: { stack %02d, num_samples=%02d, depth=%02d }\n", samples, stack_id, num_samples, stack_height)
+        stacks[samples] = stack
+      end
+      i += 1
+    end
+    stacks
   end
 end unless RUBY_ENGINE == 'truffleruby'

--- a/test/test_stackprof_tags.rb
+++ b/test/test_stackprof_tags.rb
@@ -84,6 +84,30 @@ class StackProfTagsTest < MiniTest::Test
     assert_operator StackProf::Tag.check, :==, { }
   end
 
+  def test_builtins_from_array_source_persist_between_runs
+    tags = [:thread_id, :foo]
+    StackProf::Tag.set(foo: :bar)
+    profile = StackProf.run(tags: tags) do
+      assert_operator StackProf::Tag.check, :==, { foo: :bar }
+      math
+    end
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_operator profile[:sample_tags].size, :>, 0
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true, all_samples_have_tag(profile, :thread_id)
+
+    profile = StackProf.run(tags: tags) do
+      assert_operator StackProf::Tag.check, :==, { foo: :bar }
+      math
+    end
+
+    assert_equal true, profile.key?(:sample_tags)
+    assert_operator profile[:sample_tags].size, :>, 0
+    assert_equal profile[:samples], StackProf::Tags.from(profile).size
+    assert_equal true, all_samples_have_tag(profile, :thread_id)
+  end
+
   def test_tag_sample_from_custom_tag_source
     custom_tag_source = :my_custom_tag_source
     StackProf::Tag.set(foo: :bar, tag_source: custom_tag_source)


### PR DESCRIPTION
# What

This adds support for applying tags to individual stackprof samples. Tags are read from fiber-local variable storage to add additional metadata to each sample collected. For example:

In brief:

```ruby
profile = StackProf.run(mode: :cpu, tags: [:foo]) do
  math
  StackProf::Tag.with(foo: :bar) do
    math
  end
  math
end
```


Will result in tags being added to the stackprof output, which can viewed like

```
irb > puts StackProf::Tags.from(profile).inspect
=> [{}, {}, {}, {}, {}, {}, {:foo=>"bar"}, {:foo=>"bar"}, {:foo=>"bar"}, {:foo=>"bar"}, {}, {}, {}, {}, {}]
```

In practice, I hope the utility of this will be to tag samples with useful labels like `controller=HomeController`, `action=Welcome`, to analyze specific parts of application code by tagging samples that contain them. Tags can be applied as wrappers around existing framework actions, and potentially help to correlate profiles to application domain areas.

In addition to user-specified context, some "built-in" context is also potentially useful. For now, there is only support for reading the current ruby thread thread id via `:thread_id` and current fiber id via `:fiber_id`. In future PRs, other builtins like "pid", or "pthread id" (since it looks like we already store a handle to it?), "thread name", etc. could be added. These "built-in" tags do not count towards the user tag total, `StackProf::Tag::MAX_TAGS`.

# Why

Although we can already apply tags at the profile-level with stackprof's existing `metadata` field, we cannot tag at the granularity of individual samples. Other profiling formats, such as `pprof`, have the ability to have sample-level tags.

With each tag applied to a sample, a new "index" to select on is available for aggregating samples sharing the same tag values. Open source tools like Grafana Phlare / Pyroscope can provide a means of querying the profiles based on these new dimensions.

For example  #194 is one use case served by this, since the gecko format makes threads a first class citizen. I have included a proof of concept for this use case as well, using some existing golang converter code, but a future PR could generate a "gecko report output" using the tags to map to gecko thread IDs.

# How

This approach is implemented as an optional extension to stackprof, following an approach parallel to how it collects frame samples. If the `tags` argument is not supplied, it should not change the behaviour of stackprof. If `tags` are supplied, then during stackprof's signal handler, it will check the thread that it buffered frames for a matching fiber local variables, and buffer whatever it finds.

Stackprof's design already involves periodically interrupting execution in order to collect stack traces. We take advantage of this interrupt collect the tags at a point when VM state is already already "paused" due to either the SIGPROF or SIGALARM interrupt firing, guaranteeing that they should be coherent with the stacktrace, and thus there is no "data race" that could lead to tags being mis-attributed to the wrong callchain.

Like how stackprof currently buffers frames, the tag buffering routine must by signal safe. It will only copy memory to a buffer in order to minimize the interrupt overhead, then the existing delayed job for recording the frame buffer will  end with likewise recording the tags. This is where the buffer is recorded and reset, and heap space is allocated as necessary to maintain the array of tag recording entries. Just as stackprof optimizes for repeated identical callchains, the recording process compares the current tagset with the previously recorded one in order to count repeats and reduce redundancy.

# Use cases

I've included [converter.zip](https://github.com/tmm1/stackprof/files/11263516/converter.zip) which is extracted from another codebase and facilitates converting stackprof to pprof and pprof to gecko in order to demonstrate two use cases, as those formats already have some native support for tags that we can collect here.

Future PRs could add such output formats to stackprof natively, but to reduce the scope of this PR i've included these PoC converters so that my results below can be externally replicated.

## Querying on Tags

Here is a stackprof profile, generated from one of the tests here with tags:

- [cpu_profile_with_tags.json.gz](https://github.com/tmm1/stackprof/files/11263046/cpu_profile_with_tags.json.gz)

And after converting it to pprof:

- [cpu_profile_with_tags.pb.gz](https://github.com/tmm1/stackprof/files/11263047/cpu_profile_with_tags.pb.gz)

We can verify the breakdown of tags with `go tool pprof -tags`:

```
$ go tool pprof -tags cpu_profile_with_tags.pb.gz
Main binary filename not available.
 function: Total 287.0
           190.0 (66.20%): slow
            97.0 (33.80%): fast

 thread_id: Total 391.0
            391.0 (  100%): 0x0000000100d4b128

```

Uploading this to Grafana Phlare (specifically via their brand new /pyroscope/ingest endpoint, which appears supports sample level tags in pprof), we can query on these tags:

<img width="1420" alt="Screenshot 2023-04-18 at 10 48 36 AM" src="https://user-images.githubusercontent.com/618615/232814631-5e930b60-4dd9-4b81-b2a1-9609f3446e6e.png">

[click here to see full stacktrace](https://user-images.githubusercontent.com/618615/232814877-c33b862e-3ea4-48ed-a391-bee8fdab23e1.png)


<img width="1420" alt="Screenshot 2023-04-18 at 10 49 58 AM" src="https://user-images.githubusercontent.com/618615/232815032-fd78a5ea-91d8-4dcd-b5b0-ea1500049159.png">

[click here to see full stacktrace](https://user-images.githubusercontent.com/618615/232815208-54a17397-de74-47f3-9f46-b2bd24b42a17.png)


The callchains match what we expect, chains with `slow_function` are tagged with `function: slow`, chains with `fast_function` are tagged with `function: fast`.

Note also that the displayed sample counts matches the output from `go tool pprof -tags` earlier.

We can apply tags within framework like rails, to make this transparent. For instance, the following snippet (inspired by [Pyroscope Ruby's tag auto-instrumentation](https://pyroscope.io/docs/ruby/#auto-instrumentation)):

```
module StackProf
  extend self

  def initialize_rails_hooks
    tag_wrapper = lambda do |ctrl, action|
      StackProf::Tag.with(
        action: ctrl.action_name,
        controller: ctrl.controller_name,
        &action
      )
    end

    ActionController::API.__send__(:around_action, tag_wrapper) if defined? ActionController::API
    ActionController::Base.__send__(:around_action, tag_wrapper) if defined? ActionController::Base
  end
end

StackProf.initialize_rails_hooks
```

Will result in being able to query on the tags "action" and "controller", to see where controllers are spending their time. Other frameworks exposing these sorts of hooks, or middlewares, can be used to apply and wrap with tags, potentially including other useful metadata such as request IDs.

## Multi-threaded view

Here is a PoC for using these tags to power multi-threaded profile views.

- [stackprof - cpu_profile_multiple_threads.json.gz](https://github.com/tmm1/stackprof/files/11263639/cpu_profile_multiple_threads.json.gz)
- [pprof (intermediat format) cpu_profile_multiple_threads.pb.gz](https://github.com/tmm1/stackprof/files/11263637/cpu_profile_multiple_threads.pb.gz)
- [gecko - cpu_profile_multiple_threads.gecko.json.gz](https://github.com/tmm1/stackprof/files/11263638/cpu_profile_multiple_threads.gecko.json.gz)


Viewing the resulting profile's frame graph in speedscope, we can see both threads combined:

<img width="1506" alt="Screenshot 2023-04-18 at 11 37 39 AM" src="https://user-images.githubusercontent.com/618615/232829147-63ac07b2-fed1-4ff3-a51c-eba77eaa6867.png">



But viewing the converted gecko format in [profiler.firefox.com](https://profiler.firefox.com/), we can see them show up as separate threads in the timeline at the top, and based on the sample order, which thread was active:

<img width="1500" alt="Screenshot 2023-04-18 at 11 38 13 AM" src="https://user-images.githubusercontent.com/618615/232829260-179b751c-2922-4f3a-ae2b-e6414412ea2a.png">

<img width="1500" alt="Screenshot 2023-04-18 at 11 38 25 AM" src="https://user-images.githubusercontent.com/618615/232829311-69051d24-6f40-413b-a3b2-d264b6c91030.png">


Note that the gecko converter is heavily WIP so many aspects of the visualization are off (eg, it shows timestamps even though the profile is being represented as just "samples", which is misleading. It is also naive about how much time each thread is active/inactive in the timeline, all time steps are assumed equal.

# Implementation

## Sample Tags

Sample tags are now stored on the stackprof struct, which are an array of mappings of string ids, which are indices into the `:tag_strings` field, in the order that the strings were encountered when reading tag values.

The `:sample_tags` field is an array of mixed types, effectively an array of 2-tuples. Even number array elements indicate the tag set, odd number array elements indicate how many times the previous tag set repeats:

```
irb> profile[:sample_tags]
=> [{1=>2}, 16, {1=>2, 3=>4}, 6, {1=>2}, 11, {1=>2, 3=>5}, 14, {1=>2}, 10, {1=>2, 3=>4}, 3, {1=>2}, 8, {1=>2, 3=>5}, 14, {1=>2}, 11, {1=>2, 3=>4}, 4, {1=>2}, 9, {1=>2, 3=>5}, 20, {1=>2}, 14, {1=>2, 3=>4}, 6, {1=>2}, 8, {1=>2}, 3, {1=>2, 3=>5}, 17, {1=>2}, 13, {1=>2, 3=>4}, 6, {1=>2}, 10, {1=>2, 3=>5}, 18]
irb> profile[:tag_strings]
=> ["", "thread_id", "0x0000000100a4b158", "function", "fast", "slow"]
```

## Collection Overhead

The overhead will be O(T), where `T = cardinality of tags per sample`, added to each sample. Currently this has a harcoded maximum of 16. For string keys, the maximum value is 128 bytes, and for tag values, the maximum is 512 bytes. These are arbitrary limits, to prevent enormous strings from being used as tags, while leaving some room for large unique IDs to be stored. Thus the maximum amount of string data read while buffering tags is copying up to 16 * 128 + 16 * 512 bytes, which is about 10kb, to a buffer. In practice, it is probably much less data than this which will be copied.

Values are read directly from existing variables, so most of the operations are type and nil checks, and copying data around.
There are a few function calls added for each tag collected, however:

- Reading the thread ID (optional)
  - Just the integer id of the current fiber / thread is recorded, so it should be very fast.
- Reading the thread local variable
  - Involves a function call for each one
  - Copying this to a buffer
- Recording the buffer to the _stackprof struct, accumulating a set of tags for each sample

The majority of the overhead here is in the last step of recording it, as we need to:

- Process T tags
  - Check if we already have a string ID for this tag, which is an `st_lookup`, but lets us take advantage of its hash function to check if we've seen the string before, and quickly obtain its integer representatiot.
  - Check for equality with the previous tag from the last sample (done via integer comparisons after getting string ids in above step). It is asserted that the sizes of the tag sets match first, then each value is compared with the logic short-circuiting on the first miss.
  - Accumulate the results, either by pushing a new tagset if there was no match, or incrementing the number of times the tagset repeats.

This following gist shows what the overhead looks like for tag vs frame buffer collection and recording, including a basic diff for collecting the overhead: https://gist.github.com/dalehamel/18a8f291864cee2bb3e34285f6f82c0c

It is a trivial example, but the key points are:

- Generally in the test suite at least, buffering tags is less time than buffering frames, which is the most critical overhead added here as it is done during the interrupt handler
- The majority of the overhead is in the recording of the tags, which runs in a postponed job

The overhead will scale with the number of tags and amount of tag data to be read, which the unit tests don't stress very hard.

## Storage Overhead

We can assume that lots of string values will repeat, so rather than store the same string many times, we use a `st_table` using its string hashing feature for a `strtable` to detect if we have seen a string before. The happy path is that the lookup succeeds, and it returns the integer unique id for that string. If it is a new string never seen before, we assign it an id and add it to the struct so future instances will hit and get that ID. If a sample has lots of unique tag values (request id, trace id, span id), this optimization is somewhat blunted, but reduces the storage size of tags that are consistent across multiiple samples. 

Currently the data size of the `sample_tags` field is `T = cardinality of tags per sample` `S = cardinality of samples`, so maximum size of tag storage is T * S * size of int * 2. 

However, generally expect that tags will not change from sample to sample, and tags for contiguous samples should match. This allows us to optimize: if the tagset of the current sample is exactly equal to the tagset of the previous sample, the previous sample's `repeats` counter increments rather than inserting a new tagset.

We can decode this with a helper, `StackProf::Tags.from(profile)`, to map to
the tag values, which will be 1:1 per sample:

```
irb> StackProf::Tags.from(profile)
=> [{:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118"}, {:thread_id=>"0x0000000102ddb118", :function=>"fast"}, {:thread_id=>"0x0000000102ddb118", :function=>"fast"}, {:thread_id=>"0x0000000102ddb118", :function=>"fast"}, {:thread_id=>"0x0000000102ddb118", :function=>"fast"}, {:thread_id=>"0x0000000102ddb118", :function=>"fast"}, ... ]
```

Because the tags are not stored verbatim, a helper is needed to decode them. The data structure reported on stackprof.results requires further parsing in order to "decode it", for which the ruby helper `StackProf::Tags.from(profile)` provides.

## Tag Strings

To support optimizing the storage usage of the tag collection, a single string array is maintained and is appended to for each unique new string encountered. This will be where the bulk of the added size will be to profiles featuring tags. This is a new field added to the stackprof struct, which will contain all unique tag strings. Note that by convention, the first entry will be the empty string, "", with an ID of 0, and so the numeric string IDs are the index into this 0-indexed array.

## Known limitations

My current experience is that the new tests are generally not the source of CI failures, but I have seen them fail in unexpected ways in  CI matrix testing, or after many repeated tests with the following script to try to "harden" it:

```
untilfail() {i=0; while "$@"; do :; ((i=i+1)); echo "attempt $i succeeded"; done; echo "ran $i times before failure"}
untilfail bundle exec ruby -I lib test/test_stackprof_tags.rb
```

Here are some of the rare failures that I see in CI which break assertions around the expected tag order in the tests:

- Sometimes an unexpected thread ID shows up in the tests which breaks the assertions of tag order (as it should)
  - no idea why this happens or who it belongs to, it isn't specified in the tests. Could it be coming from minitest internally? I cannot figure out where this rogue thread id comes from
  - Perhaps the test suite could be updated to drop any samples with unknown thread id in order to reduce flakiness when a rogue thread shows up in the samples?
- Sometimes a sample is missing any tags, even built-in's like `:thread_id`, even though it is configured to collect it
  - This shouldn't be possible, as it should always be able to read the current thread ID afaik
  - Test failure looks like: `1/143 samples did not contain the tag thread_id`
   - It think can also manifest as a sample missing **all** tags, including those read from the thread local storage, which can cause a test to fail due to the expected order being incorrect due to an unexpected empty tagset
  - Current theory is some nuance in how postponed jobs / interrupts work, as if i set the interval to be very small the frequency of this goes seems to go up, but at the default interval it is more rare. Perhaps some VM state is being hit that we can't read?
- Due to a race condition, it is possible for values set in the parent to not immediately propagate to the child
  - This shows up as failures in `StackProfTagsTest#test_sample_tag_persistence_from_parent`, where a sample is taken **after** the new thread has started, but before the thread local variables are set within the child thread
  - The test suite has been updated to permit either case, to prevent spurious failures due to this race condition.

I'm not sure what the root cause of each of these issues are yet, but I'll keep digging as best I can. The most concerning issue to me are the samples that lack any tags, which I cannot explain yet. However, I think this can be reasonably caveated with the disclaimer that tags are "Best effort", and not guaranteed for a sample, but that if tags are collected, they are believed to be accurate.

One major issue with the new tests however is that they are **substantially slower** than existing tests. The base stackprof suite runs in about 300ms, and the new tag suite runs in about 1500ms. This is due to a few slower tests for more complex cases which involve nested threads and ensuring the correct tags are tread under different concurrency situations. The majority of the single-threaded tests use `mode: :wall`, the default, and this makes it easier to collect samples to make assertions on. However, for multi-threaded tests, we by default currently only signal the thread that called stackprof in `:wall` mode, so these tests aren't compatible with `mode: :wall`, and thus `mode: :cpu` is required. In order to make the desired frames appear on the tests, we need to do additional math to guarantee that stackprof will collect a snapshot of the work in order for us to make assertions on. In general, tests that use `mode: :wall` are fast and those with `mode: :cpu` are slower and more nuanced.