### PR TITLE
Add valgrind support to Rakefile via ruby_memcheck gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,17 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "ruby_memcheck"
 
-Rake::TestTask.new(:test) do |t|
+test_config = lambda do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/test_*.rb"]
 end
+Rake::TestTask.new(test: :compile, &test_config)
+namespace :test do
+  RubyMemcheck.config(binary_name: "stackprof/stackprof")
+  RubyMemcheck::TestTask.new(valgrind: :compile, &test_config)
+end if RUBY_PLATFORM =~ /linux/ && `which valgrind` && $?.success?
 
 if RUBY_ENGINE == "truffleruby"
   task :compile do

--- a/stackprof.gemspec
+++ b/stackprof.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake-compiler', '~> 0.9'
   s.add_development_dependency 'mocha', '~> 0.14'
   s.add_development_dependency 'minitest', '~> 5.0'
+  s.add_development_dependency 'ruby_memcheck', '~> 1.3'
 end


### PR DESCRIPTION
This adds support for running valgrind on Linux platforms when running the test suite via `bundle exec test:valgrind`, via the https://github.com/Shopify/ruby_memcheck gem (thanks @peterzhu2118 !)

I was able to use this to detect and subsequently [fix](https://github.com/tmm1/stackprof/pull/203/commits/fb1ec663c828c005c215eeb420d493455d60a014) a memory leak in #203

On non-Linux platforms, this should be a no-op.

On linux platforms, if `valgrind` is detected on the path, it should enable a new task within the `:test` namespace, but not run it by default. Note that valgrind must be >= 3.20, per the [readme](https://github.com/Shopify/ruby_memcheck#setup), but this PR does not verify this. Users may be required to manually install valgrind per the readme if their local package manager provides one that is out of date.

Note that this adds a new development dependency