### PR TITLE
Add raw line numbers for raw mode

### DIFF
--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -145,10 +145,13 @@ class StackProfTest < MiniTest::Test
     after_monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
 
     raw = profile[:raw]
+    raw_lines = profile[:raw_lines]
     assert_equal 10, raw[-1]
     assert_equal raw[0] + 2, raw.size
+    assert_equal 10, raw_lines[-1] # seen 10 times
 
     offset = RUBY_VERSION >= '3' ? -3 : -2
+    assert_equal 140, raw_lines[offset] # sample caller is on 140
     assert_includes profile[:frames][raw[offset]][:name], 'StackProfTest#test_raw'
 
     assert_equal 10, profile[:raw_sample_timestamps].size


### PR DESCRIPTION
This commit records line numbers in raw mode along with the frame information.

Before this commit, stackprof would lose information about callee frames at a particular line.  For example, you could not answer "given a frame and line, what function do we call in to at that line?"  This commit encodes the line information along with the raw frame information so that we can answer that question.

This is probably TMI, but when we ask the Ruby frame profiler, it returns a list of memory addresses (CMEs or possibly iseqs?).  AArch64 systems guarantee the top 16 bits won't be used, x86 doesn't use them either (but possibly could in the future, but probably not). Armed with this information, we just put the line number in those top 16 bits and we don't need to allocate any extra memory when doing a profile.

For backwards compatibility, this patch splits apart the information in the `.result` method so existing tools should just work.