### PR TITLE
add `start_time_nsecs` to profile info

### DIFF
--- a/test/test_stackprof.rb
+++ b/test/test_stackprof.rb
@@ -305,6 +305,14 @@ class StackProfTest < Minitest::Test
     end
   end
 
+  def test_start_time
+    before_run_realtime = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)
+
+    profile = StackProf.run{}
+    assert profile[:start_time_nsecs] != nil
+    assert_operator profile[:start_time_nsecs], :>, before_run_realtime
+  end
+
   def math
     250_000.times do
       2 ** 10


### PR DESCRIPTION
Extends the profile data structure with a new `start_time_nsecs` field holding a timestamp (in nanos) since EPOCH

Right now, it is impossible to tell when a profile was really capture, and while that is not really relevant when inspecting individual profiles, it definite is when it comes to usage in aggregates when performing any sort of 'continuous' profiling. 

For most Shopify apps, we initially resorted to encode and try to parse the time from generated objects after capturing the profile, but that is turning out to be too brittle and hard to maintain due to the amount of workloads we have around
