### PR TITLE
Add Ruby 3.4 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ ruby-head, '3.3','3.2', '3.1', '3.0', '2.7', truffleruby ]
+        ruby: [ ruby-head, '3.4', '3.3','3.2', '3.1', '3.0', truffleruby ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This pull request adds `ruby-3.4` to CI and removes `ruby-2.7` from CI.