### PR TITLE
Read only first two bytes to check signature

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -10,10 +10,14 @@ module StackProf
 
     class << self
       def from_file(file)
-        if (content = IO.binread(file)).start_with?(MARSHAL_SIGNATURE)
-          new(Marshal.load(content))
-        else
-          from_json(JSON.parse(content))
+        File.open(file, 'rb') do |f|
+          signature_bytes = f.read(2)
+          f.rewind
+          if signature_bytes == MARSHAL_SIGNATURE
+            new(Marshal.load(f))
+          else
+            from_json(JSON.parse(f.read))
+          end
         end
       end
 


### PR DESCRIPTION
When using `stackprof` on a large trace (approximately 3.5 GiB), I noted that `stackprof` fails.

```
/opt/homebrew/lib/ruby/gems/3.4.0/gems/stackprof-0.2.27/lib/stackprof/report.rb:13:in 'IO.binread': Invalid argument @ io_fread - /Users/aidenfoxivey/src/ruby-bench/benchmarks/lobsters/zjit_exit_locations.dump (Errno::EINVAL)
        from /opt/homebrew/lib/ruby/gems/3.4.0/gems/stackprof-0.2.27/lib/stackprof/report.rb:13:in 'StackProf::Report.from_file'
        from ./bin/stackprof:78:in '<main>'
```

This is because `IO.binread` can only read a max size of 2 GiB (the number of bytes there being equivalent to the max size of a signed 32-bit integer).

Since checking the first two bytes should not require reading the whole file, this patch only reads the first two, rewinds, and then (if matching the `MARSHAL_SIGNATURE`) uses `Marshal.load`, which does allow reads over 2 GiB.

