### PR TITLE
Fix data race in GC frame recording between signal handler and postponed job.

### DIFF
--- a/ext/stackprof/stackprof.c
+++ b/ext/stackprof/stackprof.c
@@ -537,7 +537,7 @@ st_numtable_increment(st_table *table, st_data_t key, size_t increment)
 }
 
 void
-stackprof_record_sample_for_stack(int num, uint64_t sample_timestamp, int64_t timestamp_delta)
+stackprof_record_sample_for_stack(int num, VALUE *frames_buffer, int *lines_buffer, uint64_t sample_timestamp, int64_t timestamp_delta)
 {
     int i, n;
     VALUE prev_frame = Qnil;
@@ -571,8 +571,8 @@ stackprof_record_sample_for_stack(int num, uint64_t sample_timestamp, int64_t ti
 	     * in the raw buffer are stored in the opposite direction of stacks
 	     * in the frames buffer that came from Ruby. */
 	    for (i = num-1, n = 0; i >= 0; i--, n++) {
-		VALUE frame = _stackprof.frames_buffer[i];
-		int line = _stackprof.lines_buffer[i];
+		VALUE frame = frames_buffer[i];
+		int line = lines_buffer[i];
 
 		// Encode the line in to the upper 16 bits.
 		uint64_t key = ((uint64_t)line << 48) | (uint64_t)frame;
@@ -594,8 +594,8 @@ stackprof_record_sample_for_stack(int num, uint64_t sample_timestamp, int64_t ti
 	    _stackprof.raw_sample_index = _stackprof.raw_samples_len;
 	    _stackprof.raw_samples[_stackprof.raw_samples_len++] = (VALUE)num;
 	    for (i = num-1; i >= 0; i--) {
-		VALUE frame = _stackprof.frames_buffer[i];
-		int line = _stackprof.lines_buffer[i];
+		VALUE frame = frames_buffer[i];
+		int line = lines_buffer[i];
 
 		// Encode the line in to the upper 16 bits.
 		uint64_t key = ((uint64_t)line << 48) | (uint64_t)frame;
@@ -626,8 +626,8 @@ stackprof_record_sample_for_stack(int num, uint64_t sample_timestamp, int64_t ti
     }
 
     for (i = 0; i < num; i++) {
-	int line = _stackprof.lines_buffer[i];
-	VALUE frame = _stackprof.frames_buffer[i];
+	int line = lines_buffer[i];
+	VALUE frame = frames_buffer[i];
 	frame_data_t *frame_data = sample_for(frame);
 
 	if (frame_data->seen_at_sample_number != _stackprof.overall_samples) {
@@ -710,27 +710,28 @@ stackprof_record_gc_samples(void)
     for (i = 0; i < _stackprof.unrecorded_gc_samples; i++) {
 	int64_t timestamp_delta = i == 0 ? delta_to_first_unrecorded_gc_sample : NUM2LONG(_stackprof.interval);
 
+	/* Use local arrays for GC frames to avoid a data race with the
+	 * signal handler, which can overwrite _stackprof.frames_buffer
+	 * via stackprof_buffer_sample/rb_profile_frames at any time. */
+	VALUE gc_frames[2];
+	int gc_lines[2] = {0, 0};
+
       if (_stackprof.unrecorded_gc_marking_samples) {
-        _stackprof.frames_buffer[0] = FAKE_FRAME_MARK;
-        _stackprof.lines_buffer[0] = 0;
-        _stackprof.frames_buffer[1] = FAKE_FRAME_GC;
-        _stackprof.lines_buffer[1] = 0;
+        gc_frames[0] = FAKE_FRAME_MARK;
+        gc_frames[1] = FAKE_FRAME_GC;
         _stackprof.unrecorded_gc_marking_samples--;
 
-        stackprof_record_sample_for_stack(2, start_timestamp, timestamp_delta);
+        stackprof_record_sample_for_stack(2, gc_frames, gc_lines, start_timestamp, timestamp_delta);
       } else if (_stackprof.unrecorded_gc_sweeping_samples) {
-        _stackprof.frames_buffer[0] = FAKE_FRAME_SWEEP;
-        _stackprof.lines_buffer[0] = 0;
-        _stackprof.frames_buffer[1] = FAKE_FRAME_GC;
-        _stackprof.lines_buffer[1] = 0;
+        gc_frames[0] = FAKE_FRAME_SWEEP;
+        gc_frames[1] = FAKE_FRAME_GC;
 
         _stackprof.unrecorded_gc_sweeping_samples--;
 
-        stackprof_record_sample_for_stack(2, start_timestamp, timestamp_delta);
+        stackprof_record_sample_for_stack(2, gc_frames, gc_lines, start_timestamp, timestamp_delta);
       } else {
-        _stackprof.frames_buffer[0] = FAKE_FRAME_GC;
-        _stackprof.lines_buffer[0] = 0;
-        stackprof_record_sample_for_stack(1, start_timestamp, timestamp_delta);
+        gc_frames[0] = FAKE_FRAME_GC;
+        stackprof_record_sample_for_stack(1, gc_frames, gc_lines, start_timestamp, timestamp_delta);
       }
     }
     _stackprof.during_gc += _stackprof.unrecorded_gc_samples;
@@ -743,7 +744,7 @@ stackprof_record_gc_samples(void)
 static void
 stackprof_record_buffer(void)
 {
-    stackprof_record_sample_for_stack(_stackprof.buffer_count, _stackprof.buffer_time.timestamp_usec, _stackprof.buffer_time.delta_usec);
+    stackprof_record_sample_for_stack(_stackprof.buffer_count, _stackprof.frames_buffer, _stackprof.lines_buffer, _stackprof.buffer_time.timestamp_usec, _stackprof.buffer_time.delta_usec);
 
     // reset the buffer
     _stackprof.buffer_count = 0;


### PR DESCRIPTION
## Problem

Production stackprof profiles occasionally produce `raw` sample data referencing frame IDs that don't exist in the `frames` hash. Downstream consumers (e.g. we have a 'stackprof2pprof' converter) fail with errors like:

```
frame not found 1
```

Speedscope fails to import it like:

```
Importing as stackprof profile
speedscope.6f107512.js:183 Failed to load format TypeError: Cannot read properties of undefined (reading 'name')
    at a (import.bcbb2033.js:6:445)
    at import.bcbb2033.js:121:4605
    at Generator.next (<anonymous>)
    at s (import.bcbb2033.js:121:780)
```

From a production profile (`test.json`), the `raw` array contains a GC stack referencing frames `1` and `5`:

```json
"raw": [..., 2, 1, 5, 1, ...]
         // ↑num ↑frames ↑count
         // Stack of 2 frames: [1, 5], seen 1 time
```

Frame `5` (`(sweeping)`) is present in the `frames` hash:
```json
"5": {
    "name": "(sweeping)",
    "file": "",
    "total_samples": 1,
    "samples": 1
}
```

But frame `1` (`(garbage collection)`) is **missing entirely** from `frames`, despite being referenced in `raw`. The profile has `gc_samples: 1`, confirming GC was recorded — but the frame entry was lost.

## Root cause

`stackprof_record_gc_samples()` writes fake GC frame values (`FAKE_FRAME_GC`, `FAKE_FRAME_SWEEP`, etc.) directly into the **shared** `_stackprof.frames_buffer`, then calls `stackprof_record_sample_for_stack()` which reads from that same buffer. On Ruby >= 3.0 with `stackprof_use_postponed_job == 0`, the signal handler calls `stackprof_buffer_sample()` directly, which invokes `rb_profile_frames()` — overwriting `_stackprof.frames_buffer` with real stack frames.

If a signal arrives while `stackprof_record_gc_samples` (running as a postponed job) is between writing GC frames to the buffer and having `stackprof_record_sample_for_stack` process them, the GC frame data is clobbered. The raw samples may have already been serialized (loop 1 in `stackprof_record_sample_for_stack`), but the frames hash table (loop 2) reads the now-overwritten buffer and never creates entries for the fake GC frames.

This is a race condition that is difficult to reproduce in tests, but I prepared a [commit](https://github.com/dalehamel/stackprof/pull/6/changes/3cbef9184ad2fa6cb33517dd7af0bd28f0f19ee9) that creates a regression test which fails on master, passes with this patch which I believe addresses the issue by hooking into with a test `.so`. We see this issue occur relatively regularly at scale, though overall with a low frequency:

<img width="1869" height="271" alt="image" src="https://github.com/user-attachments/assets/61c8846c-0457-4420-8ff8-6a8bb5e47dee" />


## The fix

Changes `stackprof_record_sample_for_stack()` to take explicit `VALUE *frames_buffer` and `int *lines_buffer` parameters instead of reading from the shared global.

- **`stackprof_record_gc_samples()`** now uses **stack-local arrays** (`gc_frames[2]`, `gc_lines[2]`) for GC frames and passes them to `stackprof_record_sample_for_stack()`. The signal handler can overwrite `_stackprof.frames_buffer` all it wants — the local arrays are unaffected.
- **`stackprof_record_buffer()`** passes the shared `_stackprof.frames_buffer` explicitly. This is safe because `buffer_count > 0` prevents `stackprof_buffer_sample()` from re-entering while a buffer is pending.